### PR TITLE
chore: add internal stats endpoint

### DIFF
--- a/migrations/1681244251000_stats.ts
+++ b/migrations/1681244251000_stats.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.createMaterializedView(
+    'stats_inscriptions_per_block',
+    {
+      data: true,
+    },
+    `SELECT block_height,
+      COUNT(*) AS count,
+      SUM(COUNT(*)) OVER (ORDER BY block_height) AS scan_count
+    FROM locations
+    WHERE genesis = true
+    GROUP BY block_height
+    ORDER BY block_height ASC`
+  );
+
+  // unique index allows concurrent materialized view refresh
+  pgm.createIndex('stats_inscriptions_per_block', ['block_height'], { unique: true });
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropMaterializedView('stats_inscriptions_per_block');
+}

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -1,13 +1,15 @@
+import FastifyCors from '@fastify/cors';
 import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import Fastify, { FastifyPluginAsync } from 'fastify';
-import { Server } from 'http';
-import FastifyCors from '@fastify/cors';
-import { PINO_CONFIG } from '../logger';
-import { InscriptionsRoutes } from './routes/inscriptions';
-import { PgStore } from '../pg/pg-store';
-import { SatRoutes } from './routes/sats';
-import { StatusRoutes } from './routes/status';
 import FastifyMetrics from 'fastify-metrics';
+import { Server } from 'http';
+
+import { PINO_CONFIG } from '../logger';
+import { PgStore } from '../pg/pg-store';
+import { InscriptionsRoutes } from './routes/inscriptions';
+import { SatRoutes } from './routes/sats';
+import { StatsRoutes } from './routes/stats';
+import { StatusRoutes } from './routes/status';
 
 export const Api: FastifyPluginAsync<
   Record<never, never>,
@@ -17,6 +19,7 @@ export const Api: FastifyPluginAsync<
   await fastify.register(StatusRoutes);
   await fastify.register(InscriptionsRoutes);
   await fastify.register(SatRoutes);
+  await fastify.register(StatsRoutes);
 };
 
 export async function buildApiServer(args: { db: PgStore }) {

--- a/src/api/routes/stats.ts
+++ b/src/api/routes/stats.ts
@@ -1,0 +1,25 @@
+import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
+import { FastifyPluginAsync, FastifyPluginCallback } from 'fastify';
+import { Server } from 'http';
+
+const IndexRoutes: FastifyPluginCallback<Record<never, never>, Server, TypeBoxTypeProvider> = (
+  fastify,
+  options,
+  done
+) => {
+  fastify.get('/stats/inscriptions', async (request, reply) => {
+    const inscriptions = await fastify.db.getInscriptionCountPerBlock();
+    await reply.send({
+      results: inscriptions,
+    });
+  });
+  done();
+};
+
+export const StatsRoutes: FastifyPluginAsync<
+  Record<never, never>,
+  Server,
+  TypeBoxTypeProvider
+> = async fastify => {
+  await fastify.register(IndexRoutes);
+};

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -130,4 +130,10 @@ export type DbJsonContentInsert = {
   content: PgJsonb;
 };
 
+export type DbInscriptionCountPerBlock = {
+  block_height: number;
+  count: string; // COUNT() = bigint
+  scan_count: string; // COUNT() = bigint
+};
+
 export const JSON_CONTENTS_COLUMNS = ['id', 'inscription_id', 'p', 'op', 'content'];


### PR DESCRIPTION
- adds `/ordinals/stats/inscriptions` endpoint to show `count` of inscriptions genesis per block
- [ ] how do we typically add tests here?
- [ ] any types i need to be aware of?
- [ ] is it possible to hide the api from the public docs (these might be considered internal and not conforming to semver)
- [x] can these be cached and invalidated on each chainhook ingest?

sample response for `http://localhost:4000/ordinals/stats/inscriptions`

```
{"results":[[767430,"1","1"],[767753,"1","2"],[768094,"1","3"],[770110,"0","3"],[770530,"1","4"],[771290,"1","5"],[771573,"1","6"],[771694,"1","7"],[771717,"1","8"],[771971,"0","8"],[771993,"0","8"],[771994,"0","8"],[772088,"0","8"],[772119,"1","9"],[772167,"1","10"],[772642,"1","11"],[772657,"1","12"],[772676,"1","13"],[772679,"1","14"],[772731,"1","15"],[ ...
```