### PR TITLE
feat: support cursed inscriptions

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      VERCEL_ENV: ${{ contains(github.ref_name, "refs/tags") && 'production' || 'preview' }}
-      VERCEL_PROD: ${{ contains(github.ref_name, "refs/tags") && '--prod' || '' }}
+      VERCEL_ENV: ${{ contains(github.ref_name, 'refs/tags') && 'production' || 'preview' }}
+      VERCEL_PROD: ${{ contains(github.ref_name, 'refs/tags') && '--prod' || '' }}
 
     environment:
-      name: ${{ contains(github.ref_name, "refs/tags") && 'Production' || 'Preview' }}
-      url: ${{ contains(github.ref_name, "refs/tags") && 'https://ordinals-api.vercel.app/' || 'https://ordinals-api-pbcblockstack-blockstack.vercel.app/' }}
+      name: ${{ contains(github.ref_name, 'refs/tags') && 'Production' || 'Preview' }}
+      url: ${{ contains(github.ref_name, 'refs/tags') && 'https://ordinals-api.vercel.app/' || 'https://ordinals-api-pbcblockstack-blockstack.vercel.app/' }}
 
     steps:
       - uses: actions/checkout@v2

--- a/migrations/1685378650151_prev-location.ts
+++ b/migrations/1685378650151_prev-location.ts
@@ -1,0 +1,16 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.addColumns('locations', {
+    prev_output: {
+      type: 'text',
+    },
+    prev_offset: {
+      type: 'numeric',
+    },
+  });
+  pgm.createIndex('locations', ['prev_output']);
+}

--- a/migrations/1686170300438_curse-type.ts
+++ b/migrations/1686170300438_curse-type.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.addColumns('inscriptions', {
+    curse_type: {
+      type: 'text',
+    },
+  });
+}

--- a/src/api/routes/sats.ts
+++ b/src/api/routes/sats.ts
@@ -2,8 +2,17 @@ import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Type } from '@sinclair/typebox';
 import { FastifyPluginCallback } from 'fastify';
 import { Server } from 'http';
-import { NotFoundResponse, OrdinalParam, SatoshiResponse } from '../schemas';
+import {
+  InscriptionResponse,
+  LimitParam,
+  NotFoundResponse,
+  OffsetParam,
+  OrdinalParam,
+  PaginatedResponse,
+  SatoshiResponse,
+} from '../schemas';
 import { OrdinalSatoshi } from '../util/ordinal-satoshi';
+import { DEFAULT_API_LIMIT, parseDbInscriptions } from '../util/helpers';
 
 export const SatRoutes: FastifyPluginCallback<Record<never, never>, Server, TypeBoxTypeProvider> = (
   fastify,
@@ -45,6 +54,43 @@ export const SatRoutes: FastifyPluginCallback<Record<never, never>, Server, Type
         rarity: sat.rarity,
         percentile: sat.percentile,
         inscription_id: inscriptions.results[0]?.genesis_id,
+      });
+    }
+  );
+
+  fastify.get(
+    '/sats/:ordinal/inscriptions',
+    {
+      schema: {
+        operationId: 'getSatoshiInscriptions',
+        summary: 'Satoshi Inscriptions',
+        description: 'Retrieves all inscriptions associated with a single satoshi',
+        tags: ['Satoshis'],
+        params: Type.Object({
+          ordinal: OrdinalParam,
+        }),
+        querystring: Type.Object({
+          // Pagination
+          offset: Type.Optional(OffsetParam),
+          limit: Type.Optional(LimitParam),
+        }),
+        response: {
+          200: PaginatedResponse(InscriptionResponse, 'Paginated Satoshi Inscriptions Response'),
+        },
+      },
+    },
+    async (request, reply) => {
+      const limit = request.query.limit ?? DEFAULT_API_LIMIT;
+      const offset = request.query.offset ?? 0;
+      const inscriptions = await fastify.db.getInscriptions(
+        { limit, offset },
+        { sat_ordinal: BigInt(request.params.ordinal) }
+      );
+      await reply.send({
+        limit,
+        offset,
+        total: inscriptions.total,
+        results: parseDbInscriptions(inscriptions.results),
       });
     }
   );

--- a/src/api/routes/status.ts
+++ b/src/api/routes/status.ts
@@ -26,11 +26,13 @@ export const StatusRoutes: FastifyPluginCallback<
       const result = await fastify.db.sqlTransaction(async sql => {
         const block_height = await fastify.db.getChainTipBlockHeight();
         const max_inscription_number = await fastify.db.getMaxInscriptionNumber();
+        const max_cursed_inscription_number = await fastify.db.getMaxCursedInscriptionNumber();
         return {
           server_version: `ordinals-api ${SERVER_VERSION.tag} (${SERVER_VERSION.branch}:${SERVER_VERSION.commit})`,
           status: 'ready',
           block_height,
           max_inscription_number,
+          max_cursed_inscription_number,
         };
       });
       await reply.send(result);

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -249,6 +249,7 @@ export const InscriptionResponse = Type.Object(
     content_type: Type.String({ examples: ['text/plain;charset=utf-8'] }),
     content_length: Type.Integer({ examples: [59] }),
     timestamp: Type.Integer({ examples: [1677733170000] }),
+    curse_type: Nullable(Type.String({ examples: ['p2wsh'] })),
   },
   { title: 'Inscription Response' }
 );

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -77,7 +77,6 @@ export const InscriptionIdsParam = Type.Array(InscriptionIdParam, {
 });
 
 export const InscriptionNumberParam = Type.Integer({
-  minimum: 0,
   title: 'Inscription Number',
   description: 'Inscription number',
   examples: ['10500'],
@@ -282,6 +281,7 @@ export const ApiStatusResponse = Type.Object(
     status: Type.String(),
     block_height: Type.Optional(Type.Integer()),
     max_inscription_number: Type.Optional(Type.Integer()),
+    max_cursed_inscription_number: Type.Optional(Type.Integer()),
   },
   { title: 'Api Status Response' }
 );

--- a/src/api/util/helpers.ts
+++ b/src/api/util/helpers.ts
@@ -44,6 +44,7 @@ export function parseDbInscriptions(
     content_type: i.content_type,
     content_length: parseInt(i.content_length),
     timestamp: i.timestamp.valueOf(),
+    curse_type: i.curse_type,
   }));
 }
 export function parseDbInscription(item: DbFullyLocatedInscriptionResult): InscriptionResponseType {

--- a/src/chainhook/schemas.ts
+++ b/src/chainhook/schemas.ts
@@ -24,6 +24,23 @@ const InscriptionRevealedSchema = Type.Object({
 });
 export type InscriptionRevealed = Static<typeof InscriptionRevealedSchema>;
 
+const CursedInscriptionRevealedSchema = Type.Object({
+  content_bytes: Type.String(),
+  content_type: Type.String(),
+  content_length: Type.Integer(),
+  inscription_number: Type.Integer(),
+  inscription_fee: Type.Integer(),
+  inscription_id: Type.String(),
+  inscription_output_value: Type.Integer(),
+  inscriber_address: Type.String(),
+  ordinal_number: Type.Integer(),
+  ordinal_block_height: Type.Integer(),
+  ordinal_offset: Type.Integer(),
+  satpoint_post_inscription: Type.String(),
+  curse_type: Type.String(),
+});
+export type CursedInscriptionRevealed = Static<typeof CursedInscriptionRevealedSchema>;
+
 const InscriptionTransferredSchema = Type.Object({
   inscription_number: Type.Integer(),
   inscription_id: Type.String(),
@@ -36,6 +53,7 @@ const InscriptionTransferredSchema = Type.Object({
 export type InscriptionTransferred = Static<typeof InscriptionTransferredSchema>;
 
 const OrdinalOperation = Type.Object({
+  cursed_inscription_revealed: Type.Optional(CursedInscriptionRevealedSchema),
   inscription_revealed: Type.Optional(InscriptionRevealedSchema),
   inscription_transferred: Type.Optional(InscriptionTransferredSchema),
 });

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -531,6 +531,19 @@ export class PgStore extends BasePgStore {
               `PgStore inserting out-of-order inscription genesis #${args.inscription.number}, current max is #${maxNumber}`
             );
           }
+          // Is this a blessed inscription in a duplicate sat?
+          const dup = await sql<{ id: number }[]>`
+            SELECT id FROM locations WHERE sat_ordinal = ${args.location.sat_ordinal}
+          `;
+          if (dup.count > 0) {
+            logger.error(
+              {
+                block_height: args.location.block_height,
+                genesis_id: args.inscription.genesis_id,
+              },
+              `PgStore inserting duplicate blessed inscription in satoshi ${args.location.sat_ordinal}`
+            );
+          }
         }
       }
 

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -39,6 +39,8 @@ export type DbLocationInsert = {
   address: string | null;
   output: string;
   offset: PgNumeric | null;
+  prev_output: string | null;
+  prev_offset: PgNumeric | null;
   value: PgNumeric | null;
   sat_ordinal: PgNumeric;
   sat_rarity: string;
@@ -55,6 +57,8 @@ export type DbLocation = {
   address: string | null;
   output: string;
   offset: string | null;
+  prev_output: string | null;
+  prev_offset: string | null;
   value: string | null;
   sat_ordinal: string;
   sat_rarity: string;

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -29,6 +29,7 @@ export type DbFullyLocatedInscriptionResult = {
   content_type: string;
   content_length: string;
   timestamp: Date;
+  curse_type: string | null;
 };
 
 export type DbLocationInsert = {
@@ -129,6 +130,7 @@ export type DbInscriptionInsert = {
   content_length: number;
   content: PgBytea;
   fee: PgNumeric;
+  curse_type: string | null;
 };
 
 export type DbInscription = {
@@ -155,6 +157,7 @@ export const INSCRIPTIONS_COLUMNS = [
   'content_type',
   'content_length',
   'fee',
+  'curse_type',
 ];
 
 export type DbJsonContent = {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -3,6 +3,7 @@ import { IncomingMessage, Server, ServerResponse } from 'http';
 import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import {
   ChainhookPayload,
+  CursedInscriptionRevealed,
   InscriptionEvent,
   InscriptionRevealed,
   InscriptionTransferred,
@@ -80,6 +81,11 @@ export class TestChainhookPayloadBuilder {
 
   inscriptionRevealed(args: InscriptionRevealed): this {
     this.lastBlockTx.metadata.ordinal_operations.push({ inscription_revealed: args });
+    return this;
+  }
+
+  cursedInscriptionRevealed(args: CursedInscriptionRevealed): this {
+    this.lastBlockTx.metadata.ordinal_operations.push({ cursed_inscription_revealed: args });
     return this;
   }
 

--- a/tests/inscriptions.test.ts
+++ b/tests/inscriptions.test.ts
@@ -98,6 +98,7 @@ describe('/inscriptions', () => {
         timestamp: 1676913207000,
         genesis_timestamp: 1676913207000,
         genesis_tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+        curse_type: null,
       };
 
       // By inscription id
@@ -129,7 +130,7 @@ describe('/inscriptions', () => {
           .transaction({
             hash: '0x38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
           })
-          .inscriptionRevealed({
+          .cursedInscriptionRevealed({
             content_bytes: '0x48656C6C6F',
             content_type: 'image/png',
             content_length: 5,
@@ -143,6 +144,7 @@ describe('/inscriptions', () => {
             ordinal_offset: 0,
             satpoint_post_inscription:
               '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc:0:0',
+            curse_type: 'p2wsh',
           })
           .build()
       );
@@ -168,6 +170,7 @@ describe('/inscriptions', () => {
         timestamp: 1676913207000,
         genesis_timestamp: 1676913207000,
         genesis_tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+        curse_type: 'p2wsh',
       };
 
       // By inscription id
@@ -265,6 +268,7 @@ describe('/inscriptions', () => {
         timestamp: 1678122360000,
         genesis_timestamp: 1676913207000,
         genesis_tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+        curse_type: null,
       });
 
       // Transfer 2
@@ -315,6 +319,7 @@ describe('/inscriptions', () => {
         timestamp: 1678124000000,
         genesis_timestamp: 1676913207000,
         genesis_tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+        curse_type: null,
       });
     });
 
@@ -330,7 +335,7 @@ describe('/inscriptions', () => {
           .transaction({
             hash: '0x38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
           })
-          .inscriptionRevealed({
+          .cursedInscriptionRevealed({
             content_bytes: '0x48656C6C6F',
             content_type: 'image/png',
             content_length: 5,
@@ -344,6 +349,7 @@ describe('/inscriptions', () => {
             ordinal_offset: 0,
             satpoint_post_inscription:
               '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc:0:0',
+            curse_type: 'p2wsh',
           })
           .build()
       );
@@ -396,6 +402,7 @@ describe('/inscriptions', () => {
         timestamp: 1678122360000,
         genesis_timestamp: 1676913207000,
         genesis_tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+        curse_type: 'p2wsh',
       });
 
       // Transfer 2
@@ -446,6 +453,7 @@ describe('/inscriptions', () => {
         timestamp: 1678124000000,
         genesis_timestamp: 1676913207000,
         genesis_tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+        curse_type: 'p2wsh',
       });
     });
   });
@@ -918,6 +926,7 @@ describe('/inscriptions', () => {
           timestamp: 1676913207000,
           genesis_timestamp: 1676913207000,
           genesis_tx_id: '9f4a9b73b0713c5da01c0a47f97c6c001af9028d6bdd9e264dfacbc4e6790201',
+          curse_type: null,
         },
         {
           address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
@@ -941,6 +950,7 @@ describe('/inscriptions', () => {
           timestamp: 1676913207000,
           genesis_timestamp: 1676913207000,
           genesis_tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+          curse_type: null,
         },
       ]);
     });
@@ -1033,6 +1043,7 @@ describe('/inscriptions', () => {
           timestamp: 1676913207000,
           genesis_timestamp: 1676913207000,
           genesis_tx_id: '9f4a9b73b0713c5da01c0a47f97c6c001af9028d6bdd9e264dfacbc4e6790201',
+          curse_type: null,
         };
         expect(responseJson1.results[0]).toStrictEqual(result1);
 
@@ -1065,6 +1076,7 @@ describe('/inscriptions', () => {
           timestamp: 1676913207000,
           genesis_timestamp: 1676913207000,
           genesis_tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+          curse_type: null,
         };
         expect(responseJson2.results[0]).toStrictEqual(result2);
 

--- a/tests/inscriptions.test.ts
+++ b/tests/inscriptions.test.ts
@@ -117,6 +117,76 @@ describe('/inscriptions', () => {
       expect(response2.json()).toStrictEqual(expected);
     });
 
+    test('shows cursed inscription', async () => {
+      await db.updateInscriptions(
+        new TestChainhookPayloadBuilder()
+          .apply()
+          .block({
+            height: 775617,
+            hash: '0x00000000000000000002a90330a99f67e3f01eb2ce070b45930581e82fb7a91d',
+            timestamp: 1676913207,
+          })
+          .transaction({
+            hash: '0x38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+          })
+          .inscriptionRevealed({
+            content_bytes: '0x48656C6C6F',
+            content_type: 'image/png',
+            content_length: 5,
+            inscription_number: -7,
+            inscription_fee: 2805,
+            inscription_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
+            inscription_output_value: 10000,
+            inscriber_address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
+            ordinal_number: 257418248345364,
+            ordinal_block_height: 51483,
+            ordinal_offset: 0,
+            satpoint_post_inscription:
+              '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc:0:0',
+          })
+          .build()
+      );
+      const expected = {
+        address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
+        genesis_address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
+        genesis_block_hash: '00000000000000000002a90330a99f67e3f01eb2ce070b45930581e82fb7a91d',
+        genesis_block_height: 775617,
+        content_length: 5,
+        mime_type: 'image/png',
+        content_type: 'image/png',
+        genesis_fee: '2805',
+        id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
+        offset: '0',
+        number: -7,
+        value: '10000',
+        tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+        sat_ordinal: '257418248345364',
+        sat_coinbase_height: 51483,
+        output: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc:0',
+        location: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc:0:0',
+        sat_rarity: 'common',
+        timestamp: 1676913207000,
+        genesis_timestamp: 1676913207000,
+        genesis_tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+      };
+
+      // By inscription id
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/ordinals/v1/inscriptions/38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toStrictEqual(expected);
+
+      // By inscription number
+      const response2 = await fastify.inject({
+        method: 'GET',
+        url: '/ordinals/v1/inscriptions/-7',
+      });
+      expect(response2.statusCode).toBe(200);
+      expect(response2.json()).toStrictEqual(expected);
+    });
+
     test('shows correct inscription data after a transfer', async () => {
       await db.updateInscriptions(
         new TestChainhookPayloadBuilder()
@@ -235,6 +305,137 @@ describe('/inscriptions', () => {
         id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
         offset: '0',
         number: 7,
+        tx_id: 'e3af144354367de58c675e987febcb49f17d6c19e645728b833fe95408feab85',
+        value: '8000',
+        sat_ordinal: '257418248345364',
+        sat_coinbase_height: 51483,
+        output: 'e3af144354367de58c675e987febcb49f17d6c19e645728b833fe95408feab85:0',
+        location: 'e3af144354367de58c675e987febcb49f17d6c19e645728b833fe95408feab85:0:0',
+        sat_rarity: 'common',
+        timestamp: 1678124000000,
+        genesis_timestamp: 1676913207000,
+        genesis_tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+      });
+    });
+
+    test('shows correct cursed inscription data after a transfer', async () => {
+      await db.updateInscriptions(
+        new TestChainhookPayloadBuilder()
+          .apply()
+          .block({
+            height: 775617,
+            hash: '0x00000000000000000002a90330a99f67e3f01eb2ce070b45930581e82fb7a91d',
+            timestamp: 1676913207,
+          })
+          .transaction({
+            hash: '0x38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+          })
+          .inscriptionRevealed({
+            content_bytes: '0x48656C6C6F',
+            content_type: 'image/png',
+            content_length: 5,
+            inscription_number: -7,
+            inscription_fee: 2805,
+            inscription_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
+            inscription_output_value: 10000,
+            inscriber_address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
+            ordinal_number: 257418248345364,
+            ordinal_block_height: 51483,
+            ordinal_offset: 0,
+            satpoint_post_inscription:
+              '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc:0:0',
+          })
+          .build()
+      );
+
+      // Transfer 1
+      await db.updateInscriptions(
+        new TestChainhookPayloadBuilder()
+          .apply()
+          .block({ height: 775700, timestamp: 1678122360 })
+          .transaction({
+            hash: '0xbdda0d240132bab2af7f797d1507beb1acab6ad43e2c0ef7f96291aea5cc3444',
+          })
+          .inscriptionTransferred({
+            inscription_number: -7,
+            inscription_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
+            ordinal_number: 257418248345364,
+            updated_address: 'bc1p3xqwzmddceqrd6x9yxplqzkl5vucta2gqm5szpkmpuvcvgs7g8psjf8htd',
+            satpoint_pre_transfer:
+              '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc:0:0',
+            satpoint_post_transfer:
+              'bdda0d240132bab2af7f797d1507beb1acab6ad43e2c0ef7f96291aea5cc3444:0:0',
+            post_transfer_output_value: 9000,
+          })
+          .build()
+      );
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/ordinals/v1/inscriptions/38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toStrictEqual({
+        address: 'bc1p3xqwzmddceqrd6x9yxplqzkl5vucta2gqm5szpkmpuvcvgs7g8psjf8htd',
+        genesis_address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
+        genesis_block_hash: '00000000000000000002a90330a99f67e3f01eb2ce070b45930581e82fb7a91d',
+        genesis_block_height: 775617,
+        content_length: 5,
+        mime_type: 'image/png',
+        content_type: 'image/png',
+        genesis_fee: '2805',
+        id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
+        offset: '0',
+        number: -7,
+        value: '9000',
+        tx_id: 'bdda0d240132bab2af7f797d1507beb1acab6ad43e2c0ef7f96291aea5cc3444',
+        sat_ordinal: '257418248345364',
+        sat_coinbase_height: 51483,
+        output: 'bdda0d240132bab2af7f797d1507beb1acab6ad43e2c0ef7f96291aea5cc3444:0',
+        location: 'bdda0d240132bab2af7f797d1507beb1acab6ad43e2c0ef7f96291aea5cc3444:0:0',
+        sat_rarity: 'common',
+        timestamp: 1678122360000,
+        genesis_timestamp: 1676913207000,
+        genesis_tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+      });
+
+      // Transfer 2
+      await db.updateInscriptions(
+        new TestChainhookPayloadBuilder()
+          .apply()
+          .block({ height: 775701, timestamp: 1678124000 })
+          .transaction({
+            hash: '0xe3af144354367de58c675e987febcb49f17d6c19e645728b833fe95408feab85',
+          })
+          .inscriptionTransferred({
+            inscription_number: -7,
+            inscription_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
+            ordinal_number: 257418248345364,
+            updated_address: 'bc1pkjq7cerr6h53qm86k9t3dq0gqg8lcfz5jx7z4aj2mpqrjggrnass0u7qqj',
+            satpoint_pre_transfer:
+              'bdda0d240132bab2af7f797d1507beb1acab6ad43e2c0ef7f96291aea5cc3444:0:0',
+            satpoint_post_transfer:
+              'e3af144354367de58c675e987febcb49f17d6c19e645728b833fe95408feab85:0:0',
+            post_transfer_output_value: 8000,
+          })
+          .build()
+      );
+      const response2 = await fastify.inject({
+        method: 'GET',
+        url: '/ordinals/v1/inscriptions/38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
+      });
+      expect(response2.statusCode).toBe(200);
+      expect(response2.json()).toStrictEqual({
+        address: 'bc1pkjq7cerr6h53qm86k9t3dq0gqg8lcfz5jx7z4aj2mpqrjggrnass0u7qqj',
+        genesis_address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
+        genesis_block_hash: '00000000000000000002a90330a99f67e3f01eb2ce070b45930581e82fb7a91d',
+        genesis_block_height: 775617,
+        content_length: 5,
+        mime_type: 'image/png',
+        content_type: 'image/png',
+        genesis_fee: '2805',
+        id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
+        offset: '0',
+        number: -7,
         tx_id: 'e3af144354367de58c675e987febcb49f17d6c19e645728b833fe95408feab85',
         value: '8000',
         sat_ordinal: '257418248345364',

--- a/tests/sats.test.ts
+++ b/tests/sats.test.ts
@@ -71,6 +71,114 @@ describe('/sats', () => {
     );
   });
 
+  test('returns sat with more than 1 cursed inscription', async () => {
+    await db.updateInscriptions(
+      new TestChainhookPayloadBuilder()
+        .apply()
+        .block({ height: 775617 })
+        .transaction({ hash: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc' })
+        .inscriptionRevealed({
+          content_bytes: '0x48656C6C6F',
+          content_type: 'image/png',
+          content_length: 5,
+          inscription_number: -7,
+          inscription_fee: 2805,
+          inscription_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
+          inscription_output_value: 10000,
+          inscriber_address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
+          ordinal_number: 257418248345364,
+          ordinal_block_height: 650000,
+          ordinal_offset: 0,
+          satpoint_post_inscription:
+            '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc:0:0',
+        })
+        .build()
+    );
+    await db.updateInscriptions(
+      new TestChainhookPayloadBuilder()
+        .apply()
+        .block({
+          height: 775617,
+          hash: '000000000000000000002a244dc7dfcf8ab85e42d182531c27197fc125086f19',
+          timestamp: 1676913207,
+        })
+        .transaction({
+          hash: 'b9cd9489fe30b81d007f753663d12766f1368721a87f4c69056c8215caa57993',
+        })
+        .inscriptionRevealed({
+          content_bytes: '0x48656C6C6F',
+          content_type: 'image/png',
+          content_length: 5,
+          inscription_number: -1,
+          inscription_fee: 2805,
+          inscription_id: 'b9cd9489fe30b81d007f753663d12766f1368721a87f4c69056c8215caa57993i0',
+          inscription_output_value: 10000,
+          inscriber_address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
+          ordinal_number: 257418248345364,
+          ordinal_block_height: 650000,
+          ordinal_offset: 0,
+          satpoint_post_inscription:
+            'b9cd9489fe30b81d007f753663d12766f1368721a87f4c69056c8215caa57993:0:0',
+        })
+        .build()
+    );
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/ordinals/v1/sats/257418248345364/inscriptions',
+    });
+    expect(response.statusCode).toBe(200);
+    const json = response.json();
+    expect(json.total).toBe(2);
+    expect(json.results).toStrictEqual([
+      {
+        address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
+        content_length: 5,
+        content_type: 'image/png',
+        genesis_address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
+        genesis_block_hash: '163de66dc9c0949905bfe8e148bde04600223cf88d19f26fdbeba1d6e6fa0f88',
+        genesis_block_height: 775617,
+        genesis_fee: '2805',
+        genesis_timestamp: 1677803510000,
+        genesis_tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+        id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
+        location: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc:0:0',
+        mime_type: 'image/png',
+        number: -7,
+        offset: '0',
+        output: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc:0',
+        sat_coinbase_height: 51483,
+        sat_ordinal: '257418248345364',
+        sat_rarity: 'common',
+        timestamp: 1677803510000,
+        tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+        value: '10000',
+      },
+      {
+        address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
+        content_length: 5,
+        content_type: 'image/png',
+        genesis_address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
+        genesis_block_hash: '000000000000000000002a244dc7dfcf8ab85e42d182531c27197fc125086f19',
+        genesis_block_height: 775617,
+        genesis_fee: '2805',
+        genesis_timestamp: 1676913207000,
+        genesis_tx_id: 'b9cd9489fe30b81d007f753663d12766f1368721a87f4c69056c8215caa57993',
+        id: 'b9cd9489fe30b81d007f753663d12766f1368721a87f4c69056c8215caa57993i0',
+        location: 'b9cd9489fe30b81d007f753663d12766f1368721a87f4c69056c8215caa57993:0:0',
+        mime_type: 'image/png',
+        number: -1,
+        offset: '0',
+        output: 'b9cd9489fe30b81d007f753663d12766f1368721a87f4c69056c8215caa57993:0',
+        sat_coinbase_height: 51483,
+        sat_ordinal: '257418248345364',
+        sat_rarity: 'common',
+        timestamp: 1676913207000,
+        tx_id: 'b9cd9489fe30b81d007f753663d12766f1368721a87f4c69056c8215caa57993',
+        value: '10000',
+      },
+    ]);
+  });
+
   test('returns not found on invalid sats', async () => {
     const response1 = await fastify.inject({
       method: 'GET',

--- a/tests/sats.test.ts
+++ b/tests/sats.test.ts
@@ -77,7 +77,7 @@ describe('/sats', () => {
         .apply()
         .block({ height: 775617 })
         .transaction({ hash: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc' })
-        .inscriptionRevealed({
+        .cursedInscriptionRevealed({
           content_bytes: '0x48656C6C6F',
           content_type: 'image/png',
           content_length: 5,
@@ -91,6 +91,7 @@ describe('/sats', () => {
           ordinal_offset: 0,
           satpoint_post_inscription:
             '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc:0:0',
+          curse_type: 'p2wsh',
         })
         .build()
     );
@@ -105,7 +106,7 @@ describe('/sats', () => {
         .transaction({
           hash: 'b9cd9489fe30b81d007f753663d12766f1368721a87f4c69056c8215caa57993',
         })
-        .inscriptionRevealed({
+        .cursedInscriptionRevealed({
           content_bytes: '0x48656C6C6F',
           content_type: 'image/png',
           content_length: 5,
@@ -119,6 +120,7 @@ describe('/sats', () => {
           ordinal_offset: 0,
           satpoint_post_inscription:
             'b9cd9489fe30b81d007f753663d12766f1368721a87f4c69056c8215caa57993:0:0',
+          curse_type: 'p2wsh',
         })
         .build()
     );
@@ -152,6 +154,7 @@ describe('/sats', () => {
         timestamp: 1677803510000,
         tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
         value: '10000',
+        curse_type: 'p2wsh',
       },
       {
         address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
@@ -175,6 +178,7 @@ describe('/sats', () => {
         timestamp: 1676913207000,
         tx_id: 'b9cd9489fe30b81d007f753663d12766f1368721a87f4c69056c8215caa57993',
         value: '10000',
+        curse_type: 'p2wsh',
       },
     ]);
   });

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -54,14 +54,37 @@ describe('Status', () => {
         })
         .build()
     );
+    await db.updateInscriptions(
+      new TestChainhookPayloadBuilder()
+        .apply()
+        .block({ height: 791975 })
+        .transaction({ hash: 'a98d7055a77fa0b96cc31e30bb8bacf777382d1b67f1b7eca6f2014e961591c8' })
+        .inscriptionRevealed({
+          content_bytes: '0x48656C6C6F',
+          content_type: 'text/plain;charset=utf-8',
+          content_length: 5,
+          inscription_number: -2,
+          inscription_fee: 2805,
+          inscription_id: 'a98d7055a77fa0b96cc31e30bb8bacf777382d1b67f1b7eca6f2014e961591c8i0',
+          inscription_output_value: 10000,
+          inscriber_address: 'bc1pk6y72s45lcaurfwxrjyg7cf9xa9ezzuc8f5hhhzhtvhe5fgygckq0t0m5f',
+          ordinal_number: 257418248345364,
+          ordinal_block_height: 650000,
+          ordinal_offset: 0,
+          satpoint_post_inscription:
+            'a98d7055a77fa0b96cc31e30bb8bacf777382d1b67f1b7eca6f2014e961591c8:0:0',
+        })
+        .build()
+    );
 
     const response = await fastify.inject({ method: 'GET', url: '/ordinals/v1/' });
     const json = response.json();
     expect(json).toStrictEqual({
       server_version: 'ordinals-api v0.0.1 (test:123456)',
       status: 'ready',
-      block_height: 775617,
+      block_height: 791975,
       max_inscription_number: 7,
+      max_cursed_inscription_number: -2,
     });
   });
 });

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -59,7 +59,7 @@ describe('Status', () => {
         .apply()
         .block({ height: 791975 })
         .transaction({ hash: 'a98d7055a77fa0b96cc31e30bb8bacf777382d1b67f1b7eca6f2014e961591c8' })
-        .inscriptionRevealed({
+        .cursedInscriptionRevealed({
           content_bytes: '0x48656C6C6F',
           content_type: 'text/plain;charset=utf-8',
           content_length: 5,
@@ -73,6 +73,7 @@ describe('Status', () => {
           ordinal_offset: 0,
           satpoint_post_inscription:
             'a98d7055a77fa0b96cc31e30bb8bacf777382d1b67f1b7eca6f2014e961591c8:0:0',
+          curse_type: 'p2wsh',
         })
         .build()
     );


### PR DESCRIPTION
* Keep `prev_output` and `prev_offset` in the locations table so we can calculate gaps
* Add `/sats/:ordinal/inscriptions` endpoint to list all cursed inscriptions for a single sat
* Support new chainhook event `cursed_inscription_revealed`
* Save and expose `curse_type` on all endpoints