### PR TITLE
build: add codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,10 @@ jobs:
           npm run testenv:logs -- --no-color &> docker-compose-logs.txt &
 
       - name: Run tests
-        run: npm run test
+        run: npm run test -- --coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
 
       - name: Print integration environment logs
         run: cat docker-compose-logs.txt

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,7 +20,10 @@ module.exports = {
     // collectCoverage: false,
   
     // An array of glob patterns indicating a set of files for which coverage information should be collected
-    // collectCoverageFrom: undefined,
+    collectCoverageFrom: [
+      "src/**/*.ts",
+      "migrations/*.ts",
+    ],
   
     // The directory where Jest should output its coverage files
     // coverageDirectory: undefined,
@@ -59,7 +62,7 @@ module.exports = {
     // forceCoverageMatch: [],
   
     // A path to a module which exports an async function that is triggered once before all test suites
-    globalSetup: './setup.ts',
+    globalSetup: './tests/setup.ts',
   
     // A path to a module which exports an async function that is triggered once after all test suites
     // globalTeardown: undefined,
@@ -121,7 +124,7 @@ module.exports = {
     // restoreMocks: false,
   
     // The root directory that Jest should scan for tests and modules within
-    rootDir: 'tests',
+    rootDir: '',
   
     // A list of paths to directories that Jest should use to search for files in
     // roots: [
@@ -159,9 +162,11 @@ module.exports = {
     // ],
   
     // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-    // testPathIgnorePatterns: [
-    //   "/node_modules/"
-    // ],
+    testPathIgnorePatterns: [
+      "/node_modules/",
+      "/client/",
+      "/dist/"
+    ],
   
     // The regexp pattern or array of patterns that Jest uses to detect test files
     // testRegex: [],


### PR DESCRIPTION
This PR adds Codecov to the Ordinals API. I've tested locally and the reports seem to be correct. I believe we can try this out to see how flaky it behaves and we can decide if we want to change it later.

Fixes #96 