### PR TITLE
fix: send 500 code if payload ingestion fails

### DIFF
--- a/src/chainhook/server.ts
+++ b/src/chainhook/server.ts
@@ -124,10 +124,11 @@ const Chainhook: FastifyPluginCallback<Record<never, never>, Server, TypeBoxType
   fastify.post('/chainhook/inscription_feed', async (request, reply) => {
     try {
       await processInscriptionFeed(request.body, fastify.db);
+      await reply.code(200).send();
     } catch (error) {
       logger.error(error, `EventServer error processing inscription_feed`);
+      await reply.code(500).send();
     }
-    await reply.code(200).send();
   });
   done();
 };


### PR DESCRIPTION
I will reflect the change in the Chainhooks client as well (this API version does not use it yet)