### PR TITLE
fix: remove inscription_number and ordinal_number from transfers

### DIFF
--- a/src/chainhook/schemas.ts
+++ b/src/chainhook/schemas.ts
@@ -42,9 +42,7 @@ const CursedInscriptionRevealedSchema = Type.Object({
 export type CursedInscriptionRevealed = Static<typeof CursedInscriptionRevealedSchema>;
 
 const InscriptionTransferredSchema = Type.Object({
-  inscription_number: Type.Integer(),
   inscription_id: Type.String(),
-  ordinal_number: Type.Integer(),
   updated_address: Nullable(Type.String()),
   satpoint_pre_transfer: Type.String(),
   satpoint_post_transfer: Type.String(),

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -75,7 +75,6 @@ export class PgStore extends BasePgStore {
               logger.info(`PgStore rollback cursed reveal #${number} (${genesis_id})`);
             }
             if (operation.inscription_transferred) {
-              const number = operation.inscription_transferred.inscription_number;
               const genesis_id = operation.inscription_transferred.inscription_id;
               const satpoint = parseSatPoint(
                 operation.inscription_transferred.satpoint_post_transfer
@@ -83,7 +82,7 @@ export class PgStore extends BasePgStore {
               const output = `${satpoint.tx_id}:${satpoint.vout}`;
               const id = await this.rollBackInscriptionTransfer({ genesis_id, output });
               if (id) updatedInscriptionIds.add(id);
-              logger.info(`PgStore rollback transfer #${number} (${genesis_id}) ${output}`);
+              logger.info(`PgStore rollback transfer (${genesis_id}) ${output}`);
             }
           }
         }
@@ -177,31 +176,44 @@ export class PgStore extends BasePgStore {
               const transfer = operation.inscription_transferred;
               const satpoint = parseSatPoint(transfer.satpoint_post_transfer);
               const prevSatpoint = parseSatPoint(transfer.satpoint_pre_transfer);
-              const satoshi = new OrdinalSatoshi(transfer.ordinal_number);
-              const id = await this.insertInscriptionTransfer({
-                location: {
-                  block_hash,
-                  block_height,
-                  tx_id,
-                  genesis_id: transfer.inscription_id,
-                  address: transfer.updated_address,
-                  output: `${satpoint.tx_id}:${satpoint.vout}`,
-                  offset: satpoint.offset ?? null,
-                  prev_output: `${prevSatpoint.tx_id}:${prevSatpoint.vout}`,
-                  prev_offset: prevSatpoint.offset ?? null,
-                  value: transfer.post_transfer_output_value
-                    ? transfer.post_transfer_output_value.toString()
-                    : null,
-                  timestamp: event.timestamp,
-                  sat_ordinal: transfer.ordinal_number.toString(),
-                  sat_rarity: satoshi.rarity,
-                  sat_coinbase_height: satoshi.blockHeight,
-                },
+              const genesis = await this.getInscriptionGenesis({
+                genesis_id: transfer.inscription_id,
               });
-              if (id) updatedInscriptionIds.add(id);
-              logger.info(
-                `PgStore transfer #${transfer.inscription_number} (${transfer.inscription_id}) to output ${satpoint.tx_id}:${satpoint.vout} at block ${block_height}`
-              );
+              if (genesis) {
+                const inscription_id = parseInt(genesis.inscription_id);
+                await this.insertInscriptionTransfer({
+                  inscription_id,
+                  location: {
+                    block_hash,
+                    block_height,
+                    tx_id,
+                    genesis_id: transfer.inscription_id,
+                    address: transfer.updated_address,
+                    output: `${satpoint.tx_id}:${satpoint.vout}`,
+                    offset: satpoint.offset ?? null,
+                    prev_output: `${prevSatpoint.tx_id}:${prevSatpoint.vout}`,
+                    prev_offset: prevSatpoint.offset ?? null,
+                    value: transfer.post_transfer_output_value
+                      ? transfer.post_transfer_output_value.toString()
+                      : null,
+                    timestamp: event.timestamp,
+                    // TODO: Store these fields in `inscriptions` instead of `locations`.
+                    sat_ordinal: genesis.sat_ordinal,
+                    sat_rarity: genesis.sat_rarity,
+                    sat_coinbase_height: parseInt(genesis.sat_coinbase_height),
+                  },
+                });
+                updatedInscriptionIds.add(inscription_id);
+                logger.info(
+                  `PgStore transfer (${transfer.inscription_id}) to output ${satpoint.tx_id}:${satpoint.vout} at block ${block_height}`
+                );
+              } else {
+                logger.warn(
+                  { block_height, genesis_id: transfer.inscription_id },
+                  `PgStore ignoring transfer for an inscription that does not exist`
+                );
+                return;
+              }
             }
           }
         }
@@ -445,6 +457,19 @@ export class PgStore extends BasePgStore {
     });
   }
 
+  async getInscriptionGenesis(args: { genesis_id: string }): Promise<DbLocation | undefined> {
+    const results = await this.sql<DbLocation[]>`
+      SELECT ${this.sql(LOCATIONS_COLUMNS.map(c => `l.${c}`))}
+      FROM locations AS l
+      INNER JOIN inscriptions AS i ON l.inscription_id = i.id
+      WHERE i.genesis_id = ${args.genesis_id} AND genesis = TRUE
+      LIMIT 1
+    `;
+    if (results.count > 0) {
+      return results[0];
+    }
+  }
+
   async getInscriptionLocations(
     args: InscriptionIdentifier & { limit: number; offset: number }
   ): Promise<DbPaginatedResult<DbLocation>> {
@@ -662,53 +687,39 @@ export class PgStore extends BasePgStore {
   }
 
   private async insertInscriptionTransfer(args: {
+    inscription_id: number;
     location: DbLocationInsert;
-  }): Promise<number | undefined> {
-    let inscription_id: number | undefined;
-    await this.sqlWriteTransaction(async sql => {
-      const inscription = await sql<{ id: number }[]>`
-        SELECT id FROM inscriptions WHERE genesis_id = ${args.location.genesis_id}
-      `;
-      if (inscription.count === 0) {
-        logger.warn(
-          args.location,
-          `PgStore ignoring transfer for an inscription that does not exist`
-        );
-        return;
-      }
-      inscription_id = inscription[0].id;
-      const location = {
-        inscription_id,
-        block_height: args.location.block_height,
-        block_hash: args.location.block_hash,
-        tx_id: args.location.tx_id,
-        address: args.location.address,
-        output: args.location.output,
-        offset: args.location.offset,
-        prev_output: args.location.prev_output,
-        prev_offset: args.location.prev_offset,
-        value: args.location.value,
-        sat_ordinal: args.location.sat_ordinal,
-        sat_rarity: args.location.sat_rarity,
-        sat_coinbase_height: args.location.sat_coinbase_height,
-        timestamp: sql`to_timestamp(${args.location.timestamp})`,
-      };
-      await sql`
-        INSERT INTO locations ${sql(location)}
-        ON CONFLICT ON CONSTRAINT locations_inscription_id_block_height_unique DO UPDATE SET
-          block_hash = EXCLUDED.block_hash,
-          tx_id = EXCLUDED.tx_id,
-          address = EXCLUDED.address,
-          output = EXCLUDED.output,
-          "offset" = EXCLUDED.offset,
-          value = EXCLUDED.value,
-          sat_ordinal = EXCLUDED.sat_ordinal,
-          sat_rarity = EXCLUDED.sat_rarity,
-          sat_coinbase_height = EXCLUDED.sat_coinbase_height,
-          timestamp = EXCLUDED.timestamp
-      `;
-    });
-    return inscription_id;
+  }): Promise<void> {
+    const location = {
+      inscription_id: args.inscription_id,
+      block_height: args.location.block_height,
+      block_hash: args.location.block_hash,
+      tx_id: args.location.tx_id,
+      address: args.location.address,
+      output: args.location.output,
+      offset: args.location.offset,
+      prev_output: args.location.prev_output,
+      prev_offset: args.location.prev_offset,
+      value: args.location.value,
+      sat_ordinal: args.location.sat_ordinal,
+      sat_rarity: args.location.sat_rarity,
+      sat_coinbase_height: args.location.sat_coinbase_height,
+      timestamp: this.sql`to_timestamp(${args.location.timestamp})`,
+    };
+    await this.sql`
+      INSERT INTO locations ${this.sql(location)}
+      ON CONFLICT ON CONSTRAINT locations_inscription_id_block_height_unique DO UPDATE SET
+        block_hash = EXCLUDED.block_hash,
+        tx_id = EXCLUDED.tx_id,
+        address = EXCLUDED.address,
+        output = EXCLUDED.output,
+        "offset" = EXCLUDED.offset,
+        value = EXCLUDED.value,
+        sat_ordinal = EXCLUDED.sat_ordinal,
+        sat_rarity = EXCLUDED.sat_rarity,
+        sat_coinbase_height = EXCLUDED.sat_coinbase_height,
+        timestamp = EXCLUDED.timestamp
+    `;
   }
 
   private async rollBackInscriptionGenesis(args: { genesis_id: string }): Promise<void> {

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -155,9 +155,7 @@ describe('ETag cache', () => {
       .block({ height: 775618 })
       .transaction({ hash: '0x38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc' })
       .inscriptionTransferred({
-        inscription_number: 2,
         inscription_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
-        ordinal_number: 257418248345364,
         updated_address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
         satpoint_pre_transfer:
           '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc:0:0',

--- a/tests/inscriptions.test.ts
+++ b/tests/inscriptions.test.ts
@@ -300,9 +300,7 @@ describe('/inscriptions', () => {
             hash: '0xbdda0d240132bab2af7f797d1507beb1acab6ad43e2c0ef7f96291aea5cc3444',
           })
           .inscriptionTransferred({
-            inscription_number: 7,
             inscription_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
-            ordinal_number: 257418248345364,
             updated_address: 'bc1p3xqwzmddceqrd6x9yxplqzkl5vucta2gqm5szpkmpuvcvgs7g8psjf8htd',
             satpoint_pre_transfer:
               '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc:0:0',
@@ -351,9 +349,7 @@ describe('/inscriptions', () => {
             hash: '0xe3af144354367de58c675e987febcb49f17d6c19e645728b833fe95408feab85',
           })
           .inscriptionTransferred({
-            inscription_number: 7,
             inscription_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
-            ordinal_number: 257418248345364,
             updated_address: 'bc1pkjq7cerr6h53qm86k9t3dq0gqg8lcfz5jx7z4aj2mpqrjggrnass0u7qqj',
             satpoint_pre_transfer:
               'bdda0d240132bab2af7f797d1507beb1acab6ad43e2c0ef7f96291aea5cc3444:0:0',
@@ -434,9 +430,7 @@ describe('/inscriptions', () => {
             hash: '0xbdda0d240132bab2af7f797d1507beb1acab6ad43e2c0ef7f96291aea5cc3444',
           })
           .inscriptionTransferred({
-            inscription_number: -7,
             inscription_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
-            ordinal_number: 257418248345364,
             updated_address: 'bc1p3xqwzmddceqrd6x9yxplqzkl5vucta2gqm5szpkmpuvcvgs7g8psjf8htd',
             satpoint_pre_transfer:
               '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc:0:0',
@@ -485,9 +479,7 @@ describe('/inscriptions', () => {
             hash: '0xe3af144354367de58c675e987febcb49f17d6c19e645728b833fe95408feab85',
           })
           .inscriptionTransferred({
-            inscription_number: -7,
             inscription_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
-            ordinal_number: 257418248345364,
             updated_address: 'bc1pkjq7cerr6h53qm86k9t3dq0gqg8lcfz5jx7z4aj2mpqrjggrnass0u7qqj',
             satpoint_pre_transfer:
               'bdda0d240132bab2af7f797d1507beb1acab6ad43e2c0ef7f96291aea5cc3444:0:0',
@@ -573,9 +565,7 @@ describe('/inscriptions', () => {
             hash: '0xbdda0d240132bab2af7f797d1507beb1acab6ad43e2c0ef7f96291aea5cc3444',
           })
           .inscriptionTransferred({
-            inscription_number: 7,
             inscription_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
-            ordinal_number: 257418248345364,
             updated_address: 'bc1p3xqwzmddceqrd6x9yxplqzkl5vucta2gqm5szpkmpuvcvgs7g8psjf8htd',
             satpoint_pre_transfer:
               '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc:0:0',
@@ -630,9 +620,7 @@ describe('/inscriptions', () => {
             hash: '0xe3af144354367de58c675e987febcb49f17d6c19e645728b833fe95408feab85',
           })
           .inscriptionTransferred({
-            inscription_number: 7,
             inscription_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
-            ordinal_number: 257418248345364,
             updated_address: 'bc1pkjq7cerr6h53qm86k9t3dq0gqg8lcfz5jx7z4aj2mpqrjggrnass0u7qqj',
             satpoint_pre_transfer:
               'bdda0d240132bab2af7f797d1507beb1acab6ad43e2c0ef7f96291aea5cc3444:0:0',
@@ -757,9 +745,7 @@ describe('/inscriptions', () => {
             hash: '0xbdda0d240132bab2af7f797d1507beb1acab6ad43e2c0ef7f96291aea5cc3444',
           })
           .inscriptionTransferred({
-            inscription_number: 7,
             inscription_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
-            ordinal_number: 257418248345364,
             updated_address: 'bc1p3xqwzmddceqrd6x9yxplqzkl5vucta2gqm5szpkmpuvcvgs7g8psjf8htd',
             satpoint_pre_transfer:
               '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc:0:0',
@@ -771,9 +757,7 @@ describe('/inscriptions', () => {
             hash: 'abe7deebd0c6bacc9b1ddd234f9442db0530180448e934f34b9cbf3d7e6d91cb',
           })
           .inscriptionTransferred({
-            inscription_number: 8,
             inscription_id: '7ac73ecd01b9da4a7eab904655416dbfe8e03f193e091761b5a63ad0963570cdi0',
-            ordinal_number: 257418248345364,
             updated_address: 'bc1p3xqwzmddceqrd6x9yxplqzkl5vucta2gqm5szpkmpuvcvgs7g8psjf8htd',
             satpoint_pre_transfer:
               '7ac73ecd01b9da4a7eab904655416dbfe8e03f193e091761b5a63ad0963570cd:0:0',
@@ -858,9 +842,7 @@ describe('/inscriptions', () => {
             hash: '5cabafe04aaf98b1f325b0c3ffcbff904dbdb6f3d2e9e451102fda36f1056b5e',
           })
           .inscriptionTransferred({
-            inscription_number: 7,
             inscription_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dci0',
-            ordinal_number: 257418248345364,
             updated_address: 'bc1pkx5me775s748lzchytzdsw4f0lq04wssxnyk27g8fn3gee8zhjjqsn9tfp',
             satpoint_pre_transfer:
               'bdda0d240132bab2af7f797d1507beb1acab6ad43e2c0ef7f96291aea5cc3444:0:0',


### PR DESCRIPTION
Calculate genesis location preemptively to get sat ordinal information