### PR TITLE
fix: mark intractable `/inscriptions` result counts as 0 to avoid DB bottlenecks

### DIFF
--- a/src/pg/helpers.ts
+++ b/src/pg/helpers.ts
@@ -52,14 +52,17 @@ export function getIndexResultCountType(
       filters[key as keyof DbInscriptionIndexFilters] === undefined &&
       delete filters[key as keyof DbInscriptionIndexFilters]
   );
+  // How many filters do we have?
   switch (Object.keys(filters).length) {
     case 0:
       return DbInscriptionIndexResultCountType.all;
     case 1:
       if (filters.mime_type) return DbInscriptionIndexResultCountType.mimeType;
       if (filters.sat_rarity) return DbInscriptionIndexResultCountType.satRarity;
-      return DbInscriptionIndexResultCountType.custom;
+      if (filters.number || filters.genesis_id || filters.output)
+        return DbInscriptionIndexResultCountType.singleResult;
+      return DbInscriptionIndexResultCountType.intractable;
     default:
-      return DbInscriptionIndexResultCountType.custom;
+      return DbInscriptionIndexResultCountType.intractable;
   }
 }

--- a/src/pg/helpers.ts
+++ b/src/pg/helpers.ts
@@ -59,7 +59,7 @@ export function getIndexResultCountType(
     case 1:
       if (filters.mime_type) return DbInscriptionIndexResultCountType.mimeType;
       if (filters.sat_rarity) return DbInscriptionIndexResultCountType.satRarity;
-      if (filters.number || filters.genesis_id || filters.output)
+      if (filters.number || filters.genesis_id || filters.output || filters.sat_ordinal)
         return DbInscriptionIndexResultCountType.singleResult;
       return DbInscriptionIndexResultCountType.intractable;
     default:

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -375,7 +375,7 @@ export class PgStore extends BasePgStore {
           loc.value,
           loc.sat_coinbase_height,
           ${
-            countType === DbInscriptionIndexResultCountType.custom
+            countType === DbInscriptionIndexResultCountType.singleResult
               ? sql`COUNT(*) OVER() as total`
               : sql`0 as total`
           }

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -216,6 +216,8 @@ export enum DbInscriptionIndexResultCountType {
   mimeType,
   /** Filtered by sat rarity */
   satRarity,
-  /** Filtered by custom arguments */
-  custom,
+  /** Filtered by some param that yields a single result (easy to count) */
+  singleResult,
+  /** Filtered by custom arguments (very hard to count) */
+  intractable,
 }

--- a/tests/inscriptions.test.ts
+++ b/tests/inscriptions.test.ts
@@ -1587,7 +1587,8 @@ describe('/inscriptions', () => {
         });
         expect(response1.statusCode).toBe(200);
         const responseJson1 = response1.json();
-        expect(responseJson1.total).toBe(1);
+        // expect(responseJson1.total).toBe(1);
+        expect(responseJson1.results.length).toBe(1);
         expect(responseJson1.results[0].genesis_block_height).toBe(775617);
 
         const response2 = await fastify.inject({
@@ -1596,7 +1597,8 @@ describe('/inscriptions', () => {
         });
         expect(response2.statusCode).toBe(200);
         const responseJson2 = response2.json();
-        expect(responseJson2.total).toBe(1);
+        // expect(responseJson2.total).toBe(1);
+        expect(responseJson2.results.length).toBe(1);
         expect(responseJson2.results[0].genesis_block_height).toBe(778575);
 
         const response3 = await fastify.inject({
@@ -1605,7 +1607,8 @@ describe('/inscriptions', () => {
         });
         expect(response3.statusCode).toBe(200);
         const responseJson3 = response3.json();
-        expect(responseJson3.total).toBe(1);
+        // expect(responseJson3.total).toBe(1);
+        expect(responseJson3.results.length).toBe(1);
         expect(responseJson3.results[0].genesis_block_height).toBe(775617);
       });
 
@@ -1673,7 +1676,8 @@ describe('/inscriptions', () => {
         });
         expect(response1.statusCode).toBe(200);
         const responseJson1 = response1.json();
-        expect(responseJson1.total).toBe(1);
+        // expect(responseJson1.total).toBe(1);
+        expect(responseJson1.results.length).toBe(1);
         expect(responseJson1.results[0].genesis_block_hash).toBe(
           '000000000000000000039b3051705a16fcf310a70dee55742339e6da70181bf7'
         );
@@ -1743,7 +1747,8 @@ describe('/inscriptions', () => {
         });
         expect(response2.statusCode).toBe(200);
         const responseJson2 = response2.json();
-        expect(responseJson2.total).toBe(1);
+        // expect(responseJson2.total).toBe(1);
+        expect(responseJson2.results.length).toBe(1);
         expect(responseJson2.results[0].genesis_timestamp).toBe(1677731361000);
 
         const response3 = await fastify.inject({
@@ -1752,7 +1757,8 @@ describe('/inscriptions', () => {
         });
         expect(response3.statusCode).toBe(200);
         const responseJson3 = response3.json();
-        expect(responseJson3.total).toBe(1);
+        // expect(responseJson3.total).toBe(1);
+        expect(responseJson3.results.length).toBe(1);
         expect(responseJson3.results[0].genesis_timestamp).toBe(1675312161000);
       });
 
@@ -1820,7 +1826,8 @@ describe('/inscriptions', () => {
         });
         expect(response2.statusCode).toBe(200);
         const responseJson2 = response2.json();
-        expect(responseJson2.total).toBe(1);
+        // expect(responseJson2.total).toBe(1);
+        expect(responseJson2.results.length).toBe(1);
         expect(responseJson2.results[0].sat_ordinal).toBe('257418248345364');
 
         const response3 = await fastify.inject({
@@ -1829,7 +1836,8 @@ describe('/inscriptions', () => {
         });
         expect(response3.statusCode).toBe(200);
         const responseJson3 = response3.json();
-        expect(responseJson3.total).toBe(1);
+        // expect(responseJson3.total).toBe(1);
+        expect(responseJson3.results.length).toBe(1);
         expect(responseJson3.results[0].sat_ordinal).toBe('1000000000000');
       });
 
@@ -1897,7 +1905,8 @@ describe('/inscriptions', () => {
         });
         expect(response2.statusCode).toBe(200);
         const responseJson2 = response2.json();
-        expect(responseJson2.total).toBe(1);
+        // expect(responseJson2.total).toBe(1);
+        expect(responseJson2.results.length).toBe(1);
         expect(responseJson2.results[0].sat_coinbase_height).toBe(51483);
 
         const response3 = await fastify.inject({
@@ -1906,7 +1915,8 @@ describe('/inscriptions', () => {
         });
         expect(response3.statusCode).toBe(200);
         const responseJson3 = response3.json();
-        expect(responseJson3.total).toBe(1);
+        // expect(responseJson3.total).toBe(1);
+        expect(responseJson3.results.length).toBe(1);
         expect(responseJson3.results[0].sat_coinbase_height).toBe(200);
       });
 
@@ -1974,7 +1984,7 @@ describe('/inscriptions', () => {
         });
         expect(response2.statusCode).toBe(200);
         const responseJson2 = response2.json();
-        expect(responseJson2.total).toBe(1);
+        // expect(responseJson2.total).toBe(1);
         expect(responseJson2.results[0].number).toBe(50);
 
         const response3 = await fastify.inject({
@@ -1983,7 +1993,8 @@ describe('/inscriptions', () => {
         });
         expect(response3.statusCode).toBe(200);
         const responseJson3 = response3.json();
-        expect(responseJson3.total).toBe(1);
+        // expect(responseJson3.total).toBe(1);
+        expect(responseJson3.results.length).toBe(1);
         expect(responseJson3.results[0].number).toBe(7);
       });
 
@@ -2121,7 +2132,8 @@ describe('/inscriptions', () => {
         });
         expect(response1.statusCode).toBe(200);
         const responseJson1 = response1.json();
-        expect(responseJson1.total).toBe(1);
+        // expect(responseJson1.total).toBe(1);
+        expect(responseJson1.results.length).toBe(1);
         expect(responseJson1.results[0].address).toBe(
           'bc1pscktlmn99gyzlvymvrezh6vwd0l4kg06tg5rvssw0czg8873gz5sdkteqj'
         );
@@ -2132,7 +2144,8 @@ describe('/inscriptions', () => {
         });
         expect(response2.statusCode).toBe(200);
         const responseJson2 = response2.json();
-        expect(responseJson2.total).toBe(2);
+        // expect(responseJson2.total).toBe(2);
+        expect(responseJson2.results.length).toBe(2);
       });
     });
 


### PR DESCRIPTION
This will buy us time to look for a real solution (combination of materialized views, etc.)