### PR TITLE
feat: add more brc20 features

### DIFF
--- a/migrations/1692132685000_brc20-supply-view.ts
+++ b/migrations/1692132685000_brc20-supply-view.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.createMaterializedView(
+    'brc20_supplies',
+    { data: true },
+    `
+      SELECT brc20_deploy_id, SUM(amount) as minted_supply, MAX(block_height) as block_height
+      FROM brc20_mints
+      GROUP BY brc20_deploy_id
+    `
+  );
+  pgm.createIndex('brc20_supplies', ['brc20_deploy_id'], { unique: true });
+}

--- a/migrations/1692188000000_brc20-deploys-ticker-index.ts
+++ b/migrations/1692188000000_brc20-deploys-ticker-index.ts
@@ -1,0 +1,15 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.addColumns('brc20_deploys', {
+    ticker_lower: {
+      type: 'text',
+      notNull: true,
+      expressionGenerated: '(LOWER(ticker))',
+    },
+  });
+  pgm.createIndex('brc20_deploys', ['ticker_lower']);
+}

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -388,6 +388,7 @@ export const Brc20TokenResponseSchema = Type.Object(
     max_supply: Type.String({ examples: ['21000000'] }),
     mint_limit: Nullable(Type.String({ examples: ['100000'] })),
     decimals: Type.Integer({ examples: [18] }),
+    deploy_timestamp: Type.Integer({ examples: [1677733170000] }),
   },
   { title: 'BRC-20 Token Response' }
 );

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -389,6 +389,7 @@ export const Brc20TokenResponseSchema = Type.Object(
     mint_limit: Nullable(Type.String({ examples: ['100000'] })),
     decimals: Type.Integer({ examples: [18] }),
     deploy_timestamp: Type.Integer({ examples: [1677733170000] }),
+    minted_supply: Type.String({ examples: ['1000000'] }),
   },
   { title: 'BRC-20 Token Response' }
 );

--- a/src/api/util/helpers.ts
+++ b/src/api/util/helpers.ts
@@ -116,6 +116,7 @@ export function parseBrc20Tokens(items: DbBrc20Token[]): Brc20TokenResponse[] {
     max_supply: i.max,
     mint_limit: i.limit ?? null,
     decimals: i.decimals,
+    deploy_timestamp: i.deploy_timestamp.valueOf(),
   }));
 }
 

--- a/src/api/util/helpers.ts
+++ b/src/api/util/helpers.ts
@@ -117,6 +117,7 @@ export function parseBrc20Tokens(items: DbBrc20Token[]): Brc20TokenResponse[] {
     mint_limit: i.limit ?? null,
     decimals: i.decimals,
     deploy_timestamp: i.deploy_timestamp.valueOf(),
+    minted_supply: i.minted_supply,
   }));
 }
 

--- a/src/pg/brc20/brc20-pg-store.ts
+++ b/src/pg/brc20/brc20-pg-store.ts
@@ -38,7 +38,7 @@ export class Brc20PgStore {
   async getTokens(
     args: { ticker?: string[] } & DbInscriptionIndexPaging
   ): Promise<DbPaginatedResult<DbBrc20Token>> {
-    const lowerTickers = args.ticker ? args.ticker.map(t => t.toLowerCase()) : undefined;
+    const lowerTickers = args.ticker?.map(t => t.toLowerCase());
     const results = await this.sql<(DbBrc20Token & { total: number })[]>`
       SELECT
         d.id, i.genesis_id, i.number, d.block_height, d.tx_id, d.address, d.ticker, d.max, d.limit,
@@ -68,7 +68,7 @@ export class Brc20PgStore {
       block_height?: number;
     } & DbInscriptionIndexPaging
   ): Promise<DbPaginatedResult<DbBrc20Balance>> {
-    const lowerTickers = args.ticker ? args.ticker.map(t => t.toLowerCase()) : undefined;
+    const lowerTickers = args.ticker?.map(t => t.toLowerCase());
     const results = await this.sql<(DbBrc20Balance & { total: number })[]>`
       SELECT
         d.ticker,
@@ -234,7 +234,7 @@ export class Brc20PgStore {
       const brc20Transfer = await sql<DbBrc20Transfer[]>`
         SELECT ${sql(BRC20_TRANSFERS_COLUMNS.map(c => `t.${c}`))}
         FROM locations AS l
-        INNER JOIN brc20_transfers AS t ON t.inscription_id = l.inscription_id 
+        INNER JOIN brc20_transfers AS t ON t.inscription_id = l.inscription_id
         WHERE l.inscription_id = ${args.inscription_id}
           AND l.block_height <= ${args.location.block_height}
         LIMIT 3

--- a/src/pg/brc20/brc20-pg-store.ts
+++ b/src/pg/brc20/brc20-pg-store.ts
@@ -42,9 +42,11 @@ export class Brc20PgStore {
     const results = await this.sql<(DbBrc20Token & { total: number })[]>`
       SELECT
         d.id, i.genesis_id, i.number, d.block_height, d.tx_id, d.address, d.ticker, d.max, d.limit,
-        d.decimals, COUNT(*) OVER() as total
+        d.decimals, l.timestamp as deploy_timestamp, COUNT(*) OVER() as total
       FROM brc20_deploys AS d
       INNER JOIN inscriptions AS i ON i.id = d.inscription_id
+      INNER JOIN genesis_locations AS g ON g.inscription_id = d.inscription_id
+      INNER JOIN locations AS l ON l.id = g.location_id
       ${lowerTickers ? this.sql`WHERE LOWER(d.ticker) IN ${this.sql(lowerTickers)}` : this.sql``}
       OFFSET ${args.offset}
       LIMIT ${args.limit}

--- a/src/pg/brc20/brc20-pg-store.ts
+++ b/src/pg/brc20/brc20-pg-store.ts
@@ -50,7 +50,7 @@ export class Brc20PgStore {
       INNER JOIN genesis_locations AS g ON g.inscription_id = d.inscription_id
       INNER JOIN locations AS l ON l.id = g.location_id
       LEFT JOIN brc20_supplies AS s ON d.id = s.brc20_deploy_id
-      ${lowerTickers ? this.sql`WHERE LOWER(d.ticker) IN ${this.sql(lowerTickers)}` : this.sql``}
+      ${lowerTickers ? this.sql`WHERE d.ticker_lower IN ${this.sql(lowerTickers)}` : this.sql``}
       OFFSET ${args.offset}
       LIMIT ${args.limit}
     `;
@@ -88,8 +88,8 @@ export class Brc20PgStore {
       }
       WHERE
         b.address = ${args.address}
-        ${lowerTickers ? this.sql`AND LOWER(d.ticker) IN ${this.sql(lowerTickers)}` : this.sql``}
         ${args.block_height ? this.sql`AND l.block_height <= ${args.block_height}` : this.sql``}
+        ${lowerTickers ? this.sql`AND d.ticker_lower IN ${this.sql(lowerTickers)}` : this.sql``}
       GROUP BY d.ticker
       LIMIT ${args.limit}
       OFFSET ${args.offset}
@@ -107,7 +107,7 @@ export class Brc20PgStore {
         FROM brc20_events AS e
         INNER JOIN brc20_deploys AS d ON d.id = e.brc20_deploy_id
         INNER JOIN inscriptions AS i ON i.id = e.inscription_id
-        WHERE LOWER(d.ticker) = LOWER(${args.ticker})
+        WHERE d.ticker_lower = LOWER(${args.ticker})
         ORDER BY i.number DESC
         LIMIT ${args.limit}
         OFFSET ${args.offset}

--- a/src/pg/brc20/brc20-pg-store.ts
+++ b/src/pg/brc20/brc20-pg-store.ts
@@ -153,8 +153,8 @@ export class Brc20PgStore {
       const [supply, holders, minted] = throwOnFirstRejected(settles);
       return {
         max_supply: supply[0].max,
-        minted_supply: minted[0].minted_supply ?? '0',
-        holders: holders[0].count,
+        minted_supply: minted[0]?.minted_supply ?? '0',
+        holders: holders[0]?.count ?? '0',
       };
     });
   }

--- a/src/pg/brc20/types.ts
+++ b/src/pg/brc20/types.ts
@@ -45,6 +45,7 @@ export type DbBrc20Token = {
   max: string;
   limit?: string;
   decimals: number;
+  deploy_timestamp: number;
 };
 
 export type DbBrc20Supply = {

--- a/src/pg/brc20/types.ts
+++ b/src/pg/brc20/types.ts
@@ -46,6 +46,7 @@ export type DbBrc20Token = {
   limit?: string;
   decimals: number;
   deploy_timestamp: number;
+  minted_supply: string;
 };
 
 export type DbBrc20Supply = {

--- a/src/pg/helpers.ts
+++ b/src/pg/helpers.ts
@@ -15,3 +15,25 @@ export function getInscriptionRecursion(content: PgBytea): string[] {
   }
   return result;
 }
+
+/**
+ * Returns the values from settled Promise results.
+ * Throws if any Promise is rejected.
+ * This can be used with Promise.allSettled to get the values from all promises,
+ * instead of Promise.all which will swallow following unhandled rejections.
+ * @param settles - Array of `Promise.allSettled()` results
+ * @returns Array of Promise result values
+ */
+export function throwOnFirstRejected<T extends any[]>(settles: {
+  [K in keyof T]: PromiseSettledResult<T[K]>;
+}): T {
+  const values: T = [] as any;
+  for (const promise of settles) {
+    if (promise.status === 'rejected') throw promise.reason;
+
+    // Note: Pushing to result `values` array is required for type inference
+    // Compared to e.g. `settles.map(s => s.value)`
+    values.push(promise.value);
+  }
+  return values;
+}

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -218,6 +218,7 @@ export class PgStore extends BasePgStore {
       // we can respond to the chainhook node with a `200` HTTP code as soon as possible.
       const viewRefresh = Promise.allSettled([
         this.normalizeInscriptionCount({ min_block_height: updatedBlockHeightMin }),
+        this.refreshMaterializedView('brc20_supplies'),
       ]);
       // Only wait for these on tests.
       if (isTestEnv) await viewRefresh;

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -1,8 +1,20 @@
+import {
+  BasePgStore,
+  PgSqlClient,
+  connectPostgres,
+  logger,
+  runMigrations,
+} from '@hirosystems/api-toolkit';
 import { BitcoinEvent, Payload } from '@hirosystems/chainhook-client';
+import * as path from 'path';
+import * as postgres from 'postgres';
 import { Order, OrderBy } from '../api/schemas';
 import { isProdEnv, isTestEnv, normalizedHexString, parseSatPoint } from '../api/util/helpers';
 import { OrdinalSatoshi } from '../api/util/ordinal-satoshi';
 import { ENV } from '../env';
+import { Brc20PgStore } from './brc20/brc20-pg-store';
+import { CountsPgStore } from './counts/counts-pg-store';
+import { getIndexResultCountType } from './counts/helpers';
 import { getInscriptionRecursion } from './helpers';
 import {
   DbFullyLocatedInscriptionResult,
@@ -23,18 +35,6 @@ import {
   INSCRIPTIONS_COLUMNS,
   LOCATIONS_COLUMNS,
 } from './types';
-import {
-  BasePgStore,
-  PgSqlClient,
-  connectPostgres,
-  logger,
-  runMigrations,
-} from '@hirosystems/api-toolkit';
-import * as path from 'path';
-import { Brc20PgStore } from './brc20/brc20-pg-store';
-import { CountsPgStore } from './counts/counts-pg-store';
-import { getIndexResultCountType } from './counts/helpers';
-import * as postgres from 'postgres';
 
 export const MIGRATIONS_DIR = path.join(__dirname, '../../migrations');
 

--- a/tests/brc20.test.ts
+++ b/tests/brc20.test.ts
@@ -1717,6 +1717,34 @@ describe('BRC-20', () => {
   });
 
   describe('routes', () => {
+    test('token endpoint', async () => {
+      await db.updateInscriptions(
+        new TestChainhookPayloadBuilder()
+          .apply()
+          .block({ height: 775617 })
+          .transaction({ hash: randomHash() })
+          .inscriptionRevealed(
+            brc20Reveal({
+              json: {
+                p: 'brc-20',
+                op: 'deploy',
+                tick: 'PEPE',
+                max: '21000000',
+              },
+              number: 5,
+              tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+              address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
+            })
+          )
+          .build()
+      );
+      const response = await fastify.inject({
+        method: 'GET',
+        url: `/ordinals/brc-20/tokens/PEPE`,
+      });
+      expect(response.statusCode).toBe(200);
+    });
+
     test('filter tickers by ticker prefix', async () => {
       await db.updateInscriptions(
         new TestChainhookPayloadBuilder()

--- a/tests/brc20.test.ts
+++ b/tests/brc20.test.ts
@@ -442,6 +442,7 @@ describe('BRC-20', () => {
           ticker: 'PEPE',
           tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
           deploy_timestamp: 1677811111000,
+          minted_supply: '0',
         },
       ]);
     });
@@ -516,6 +517,7 @@ describe('BRC-20', () => {
           ticker: 'PEPE',
           tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
           deploy_timestamp: 1677803510000,
+          minted_supply: '0',
         },
       ]);
     });
@@ -590,6 +592,7 @@ describe('BRC-20', () => {
           ticker: 'PEPE',
           tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
           deploy_timestamp: 1677803510000,
+          minted_supply: '0',
         },
       ]);
       const response2 = await fastify.inject({
@@ -611,6 +614,7 @@ describe('BRC-20', () => {
           ticker: 'PEPE',
           tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
           deploy_timestamp: 1677803510000,
+          minted_supply: '0',
         },
       ]);
     });
@@ -728,6 +732,19 @@ describe('BRC-20', () => {
           transferrable_balance: '0',
         },
       ]);
+
+      const response3 = await fastify.inject({
+        method: 'GET',
+        url: `/ordinals/brc-20/tokens?ticker=PEPE`,
+      });
+      expect(response3.statusCode).toBe(200);
+      const responseJson3 = response3.json();
+      expect(responseJson3.total).toBe(1);
+      expect(responseJson3.results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ ticker: 'PEPE', minted_supply: '350000' }),
+        ])
+      );
     });
 
     test('rollback mints deduct balance correctly', async () => {

--- a/tests/brc20.test.ts
+++ b/tests/brc20.test.ts
@@ -2,7 +2,7 @@ import { cycleMigrations } from '@hirosystems/api-toolkit';
 import { buildApiServer } from '../src/api/init';
 import { MIGRATIONS_DIR, PgStore } from '../src/pg/pg-store';
 import { DbInscriptionInsert } from '../src/pg/types';
-import { TestChainhookPayloadBuilder, TestFastifyServer, brc20Reveal } from './helpers';
+import { TestChainhookPayloadBuilder, TestFastifyServer, brc20Reveal, randomHash } from './helpers';
 import { brc20FromInscription } from '../src/pg/brc20/helpers';
 
 describe('BRC-20', () => {
@@ -403,6 +403,7 @@ describe('BRC-20', () => {
           .block({
             height: 775617,
             hash: '00000000000000000002a90330a99f67e3f01eb2ce070b45930581e82fb7a91d',
+            timestamp: 1677811111,
           })
           .transaction({
             hash: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
@@ -440,6 +441,7 @@ describe('BRC-20', () => {
           max_supply: '21000000',
           ticker: 'PEPE',
           tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+          deploy_timestamp: 1677811111000,
         },
       ]);
     });
@@ -513,6 +515,7 @@ describe('BRC-20', () => {
           number: 5,
           ticker: 'PEPE',
           tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+          deploy_timestamp: 1677803510000,
         },
       ]);
     });
@@ -586,6 +589,7 @@ describe('BRC-20', () => {
           number: 5,
           ticker: 'PEPE',
           tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+          deploy_timestamp: 1677803510000,
         },
       ]);
       const response2 = await fastify.inject({
@@ -606,6 +610,7 @@ describe('BRC-20', () => {
           number: 5,
           ticker: 'PEPE',
           tx_id: '38c46a8bf7ec90bc7f6b797e7dc84baa97f4e5fd4286b92fe1b50176d03b18dc',
+          deploy_timestamp: 1677803510000,
         },
       ]);
     });


### PR DESCRIPTION
### Description

So far commits are conventional and can be rebased.

- closes #159 
- adds `ticker_lower` ~`char(4)`~ `text` generated column to reduce total scan of `LOWER(ticker)` queries
- adds minted supplies materialized view (for token endpoints)
- adds deploy timestamp to token endpoints
- changes brc-20 ticker filter to prefix search instead of exact matches
- minor refactors

---

### Todo

- [x] Should new migrations be merged into original migrations (since they aren't in develop yet)? **Already building BRC-20 index, so likely keep as new migrations**
- [x] ~Should original ticker column also be changed to `char(4)` instead of `text`?~
- [x] ~The only failing test also fails in the base branch~
