### PR TITLE
fix: optimize inscription and brc-20 inserts

### DIFF
--- a/src/admin-rpc/init.ts
+++ b/src/admin-rpc/init.ts
@@ -1,0 +1,52 @@
+import Fastify, { FastifyPluginCallback } from 'fastify';
+import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
+import { PgStore } from '../pg/pg-store';
+import { Server } from 'http';
+import { Type } from '@sinclair/typebox';
+import { PINO_LOGGER_CONFIG, logger } from '@hirosystems/api-toolkit';
+
+export const AdminApi: FastifyPluginCallback<Record<never, never>, Server, TypeBoxTypeProvider> = (
+  fastify,
+  options,
+  done
+) => {
+  fastify.post(
+    '/brc-20/scan',
+    {
+      schema: {
+        description: 'Scan for BRC-20 operations within a block range',
+        querystring: Type.Object({
+          start_block: Type.Integer(),
+          end_block: Type.Integer(),
+        }),
+      },
+    },
+    async (request, reply) => {
+      const startBlock = request.query.start_block;
+      const endBlock = request.query.end_block;
+      logger.info(
+        `AdminRPC scanning for BRC-20 operations from block ${startBlock} to block ${endBlock}`
+      );
+      // TODO: Provide a way to stop this scan without restarting.
+      fastify.db.brc20
+        .scanBlocks(startBlock, endBlock)
+        .then(() => logger.info(`AdminRPC finished scanning for BRC-20 operations`))
+        .catch(error => logger.error(error, `AdminRPC failed to scan for BRC-20`));
+      await reply.code(200).send();
+    }
+  );
+
+  done();
+};
+
+export async function buildAdminRpcServer(args: { db: PgStore }) {
+  const fastify = Fastify({
+    trustProxy: true,
+    logger: PINO_LOGGER_CONFIG,
+  }).withTypeProvider<TypeBoxTypeProvider>();
+
+  fastify.decorate('db', args.db);
+  await fastify.register(AdminApi, { prefix: '/ordinals/admin' });
+
+  return fastify;
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -18,6 +18,8 @@ const schema = Type.Object({
   API_HOST: Type.String({ default: '0.0.0.0' }),
   /** Port in which to serve the API */
   API_PORT: Type.Number({ default: 3000, minimum: 0, maximum: 65535 }),
+  /** Port in which to serve the Admin RPC interface */
+  ADMIN_RPC_PORT: Type.Number({ default: 3001, minimum: 0, maximum: 65535 }),
   /** Port in which to receive chainhook events */
   EVENT_PORT: Type.Number({ default: 3099, minimum: 0, maximum: 65535 }),
   /** Event server body limit (bytes) */

--- a/src/env.ts
+++ b/src/env.ts
@@ -49,6 +49,9 @@ const schema = Type.Object({
   PG_CONNECTION_POOL_MAX: Type.Number({ default: 10 }),
   PG_IDLE_TIMEOUT: Type.Number({ default: 30 }),
   PG_MAX_LIFETIME: Type.Number({ default: 60 }),
+
+  /** Enables BRC-20 processing in write mode APIs */
+  BRC20_BLOCK_SCAN_ENABLED: Type.Boolean({ default: true }),
 });
 type Env = Static<typeof schema>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { startChainhookServer } from './chainhook/server';
 import { ENV } from './env';
 import { ApiMetrics } from './metrics/metrics';
 import { PgStore } from './pg/pg-store';
+import { buildAdminRpcServer } from './admin-rpc/init';
 
 async function initBackgroundServices(db: PgStore) {
   logger.info('Initializing background services...');
@@ -16,6 +17,16 @@ async function initBackgroundServices(db: PgStore) {
       await server.close();
     },
   });
+
+  const adminRpcServer = await buildAdminRpcServer({ db });
+  registerShutdownConfig({
+    name: 'Admin RPC Server',
+    forceKillable: false,
+    handler: async () => {
+      await adminRpcServer.close();
+    },
+  });
+  await adminRpcServer.listen({ host: ENV.API_HOST, port: ENV.ADMIN_RPC_PORT });
 }
 
 async function initApiService(db: PgStore) {

--- a/src/pg/brc20/brc20-pg-store.ts
+++ b/src/pg/brc20/brc20-pg-store.ts
@@ -42,6 +42,12 @@ export class Brc20PgStore {
     return partials?.reduce((acc, curr) => this.sql`${acc} OR ${curr}`);
   }
 
+  /**
+   * Perform a scan of all inscriptions stored in the DB divided by block in order to look for
+   * BRC-20 operations.
+   * @param startBlock - Start at block height
+   * @param endBlock - End at block height
+   */
   async scanBlocks(startBlock?: number, endBlock?: number): Promise<void> {
     const range = await this.parent.sql<{ min: number; max: number }[]>`
       SELECT

--- a/src/pg/brc20/helpers.ts
+++ b/src/pg/brc20/helpers.ts
@@ -47,51 +47,53 @@ const Brc20C = TypeCompiler.Compile(Brc20Schema);
 export type Brc20 = Static<typeof Brc20Schema>;
 
 export function brc20FromInscription(inscription: DbInscriptionInsert): Brc20 | undefined {
-  if (
-    inscription.mime_type.startsWith('text/plain') ||
-    inscription.mime_type.startsWith('application/json')
-  ) {
-    try {
-      const buf =
-        typeof inscription.content === 'string'
-          ? hexToBuffer(inscription.content)
-          : inscription.content;
-      const json = JSON.parse(buf.toString('utf-8'));
-      if (Brc20C.Check(json)) {
-        // Check ticker byte length
-        if (Buffer.from(json.tick).length > 4) {
+  if (inscription.number < 0) return;
+  if (inscription.mime_type !== 'text/plain' && inscription.mime_type !== 'application/json')
+    return;
+  const buf =
+    typeof inscription.content === 'string'
+      ? hexToBuffer(inscription.content)
+      : inscription.content;
+  return brc20FromInscriptionContent(buf);
+}
+
+export function brc20FromInscriptionContent(content: Buffer): Brc20 | undefined {
+  try {
+    const json = JSON.parse(content.toString('utf-8'));
+    if (Brc20C.Check(json)) {
+      // Check ticker byte length
+      if (Buffer.from(json.tick).length > 4) {
+        return;
+      }
+      // Check numeric values.
+      const uint64_max = BigNumber('18446744073709551615');
+      if (json.op === 'deploy') {
+        const max = BigNumber(json.max);
+        if (max.isNaN() || max.isZero() || max.isGreaterThan(uint64_max)) {
           return;
         }
-        // Check numeric values.
-        const uint64_max = BigNumber('18446744073709551615');
-        if (json.op === 'deploy') {
-          const max = BigNumber(json.max);
-          if (max.isNaN() || max.isZero() || max.isGreaterThan(uint64_max)) {
-            return;
-          }
-          if (json.lim) {
-            const lim = BigNumber(json.lim);
-            if (lim.isNaN() || lim.isZero() || lim.isGreaterThan(uint64_max)) {
-              return;
-            }
-          }
-          if (json.dec) {
-            // `dec` can have a value of 0 but must be no more than 18.
-            const dec = BigNumber(json.dec);
-            if (dec.isNaN() || dec.isGreaterThan(18)) {
-              return;
-            }
-          }
-        } else {
-          const amt = BigNumber(json.amt);
-          if (amt.isNaN() || amt.isZero() || amt.isGreaterThan(uint64_max)) {
+        if (json.lim) {
+          const lim = BigNumber(json.lim);
+          if (lim.isNaN() || lim.isZero() || lim.isGreaterThan(uint64_max)) {
             return;
           }
         }
-        return json;
+        if (json.dec) {
+          // `dec` can have a value of 0 but must be no more than 18.
+          const dec = BigNumber(json.dec);
+          if (dec.isNaN() || dec.isGreaterThan(18)) {
+            return;
+          }
+        }
+      } else {
+        const amt = BigNumber(json.amt);
+        if (amt.isNaN() || amt.isZero() || amt.isGreaterThan(uint64_max)) {
+          return;
+        }
       }
-    } catch (error) {
-      // Not a BRC-20 inscription.
+      return json;
     }
+  } catch (error) {
+    // Not a BRC-20 inscription.
   }
 }

--- a/src/pg/brc20/types.ts
+++ b/src/pg/brc20/types.ts
@@ -40,9 +40,9 @@ export type DbBrc20Deploy = {
 
 export type DbBrc20Transfer = {
   id: string;
-  inscription_id: number;
-  brc20_deploy_id: number;
-  block_height: number;
+  inscription_id: string;
+  brc20_deploy_id: string;
+  block_height: string;
   tx_id: string;
   from_address: string;
   to_address?: string;

--- a/src/pg/brc20/types.ts
+++ b/src/pg/brc20/types.ts
@@ -7,8 +7,8 @@ export type DbBrc20ScannedInscription = DbLocation & {
 };
 
 export type DbBrc20DeployInsert = {
-  inscription_id: number;
-  block_height: number;
+  inscription_id: string;
+  block_height: string;
   tx_id: string;
   address: string;
   ticker: string;

--- a/src/pg/brc20/types.ts
+++ b/src/pg/brc20/types.ts
@@ -1,4 +1,10 @@
 import { PgNumeric } from '@hirosystems/api-toolkit';
+import { DbLocation } from '../types';
+
+export type DbBrc20ScannedInscription = DbLocation & {
+  genesis: boolean;
+  content: string;
+};
 
 export type DbBrc20DeployInsert = {
   inscription_id: number;
@@ -9,6 +15,15 @@ export type DbBrc20DeployInsert = {
   max: string;
   decimals: string;
   limit: string | null;
+};
+
+export type DbBrc20MintInsert = {
+  inscription_id: string;
+  brc20_deploy_id: string;
+  block_height: string;
+  tx_id: string;
+  address: string;
+  amount: string;
 };
 
 export type DbBrc20Deploy = {
@@ -73,21 +88,13 @@ export enum DbBrc20BalanceTypeId {
 }
 
 export type DbBrc20BalanceInsert = {
-  inscription_id: number;
-  location_id: number;
-  brc20_deploy_id: number;
+  inscription_id: PgNumeric;
+  location_id: PgNumeric;
+  brc20_deploy_id: PgNumeric;
   address: string | null;
   avail_balance: PgNumeric;
   trans_balance: PgNumeric;
   type: DbBrc20BalanceTypeId;
-};
-
-export type DbBrc20EventInsert = {
-  inscription_id: number;
-  brc20_deploy_id: string;
-  deploy_id: string | null;
-  mint_id: string | null;
-  transfer_id: string | null;
 };
 
 export const BRC20_DEPLOYS_COLUMNS = [
@@ -111,13 +118,4 @@ export const BRC20_TRANSFERS_COLUMNS = [
   'from_address',
   'to_address',
   'amount',
-];
-
-export const BRC20_EVENTS_COLUMNS = [
-  'id',
-  'inscription_id',
-  'brc20_deploy_id',
-  'deploy_id',
-  'mint_id',
-  'transfer_id',
 ];

--- a/src/pg/counts/counts-pg-store.ts
+++ b/src/pg/counts/counts-pg-store.ts
@@ -63,21 +63,35 @@ export class CountsPgStore {
     }
   }
 
-  async applyInscription(args: { inscription: DbInscriptionInsert }): Promise<void> {
+  async applyInscriptions(writes: DbInscriptionInsert[]): Promise<void> {
+    if (writes.length === 0) return;
     await this.parent.sqlWriteTransaction(async sql => {
+      const mimeType = new Map<string, any>();
+      const rarity = new Map<string, any>();
+      const type = new Map<string, any>();
+      for (const i of writes) {
+        const t = i.number < 0 ? 'cursed' : 'blessed';
+        mimeType.set(i.mime_type, {
+          mime_type: i.mime_type,
+          count: mimeType.get(i.mime_type)?.count ?? 0 + 1,
+        });
+        rarity.set(i.sat_rarity, {
+          sat_rarity: i.sat_rarity,
+          count: rarity.get(i.sat_rarity)?.count ?? 0 + 1,
+        });
+        type.set(t, { type: t, count: type.get(t)?.count ?? 0 + 1 });
+      }
       await sql`
-        INSERT INTO counts_by_mime_type ${sql({ mime_type: args.inscription.mime_type })}
-        ON CONFLICT (mime_type) DO UPDATE SET count = counts_by_mime_type.count + 1
+        INSERT INTO counts_by_mime_type ${sql([...mimeType.values()])}
+        ON CONFLICT (mime_type) DO UPDATE SET count = counts_by_mime_type.count + EXCLUDED.count
       `;
       await sql`
-        INSERT INTO counts_by_sat_rarity ${sql({ sat_rarity: args.inscription.sat_rarity })}
-        ON CONFLICT (sat_rarity) DO UPDATE SET count = counts_by_sat_rarity.count + 1
+        INSERT INTO counts_by_sat_rarity ${sql([...rarity.values()])}
+        ON CONFLICT (sat_rarity) DO UPDATE SET count = counts_by_sat_rarity.count + EXCLUDED.count
       `;
       await sql`
-        INSERT INTO counts_by_type ${sql({
-          type: args.inscription.number < 0 ? DbInscriptionType.cursed : DbInscriptionType.blessed,
-        })}
-        ON CONFLICT (type) DO UPDATE SET count = counts_by_type.count + 1
+        INSERT INTO counts_by_type ${sql([...type.values()])}
+        ON CONFLICT (type) DO UPDATE SET count = counts_by_type.count + EXCLUDED.count
       `;
     });
   }
@@ -105,41 +119,37 @@ export class CountsPgStore {
     });
   }
 
-  async applyGenesisLocation(args: {
-    old?: DbLocationPointer;
-    new: DbLocationPointer;
-  }): Promise<void> {
+  async applyLocations(
+    writes: { old_address: string | null; new_address: string | null }[],
+    genesis: boolean = true
+  ): Promise<void> {
+    if (writes.length === 0) return;
     await this.parent.sqlWriteTransaction(async sql => {
-      if (args.old && args.old.address) {
-        await sql`
-          UPDATE counts_by_genesis_address SET count = count - 1 WHERE address = ${args.old.address}
-        `;
+      const table = genesis ? sql`counts_by_genesis_address` : sql`counts_by_address`;
+      const oldAddr = new Map<string, any>();
+      const newAddr = new Map<string, any>();
+      for (const i of writes) {
+        if (i.old_address)
+          oldAddr.set(i.old_address, {
+            address: i.old_address,
+            count: oldAddr.get(i.old_address)?.count ?? 0 + 1,
+          });
+        if (i.new_address)
+          newAddr.set(i.new_address, {
+            address: i.new_address,
+            count: newAddr.get(i.new_address)?.count ?? 0 + 1,
+          });
       }
-      if (args.new.address) {
+      if (oldAddr.size)
         await sql`
-          INSERT INTO counts_by_genesis_address ${sql({ address: args.new.address })}
-          ON CONFLICT (address) DO UPDATE SET count = counts_by_genesis_address.count + 1
+          INSERT INTO ${table} ${sql([...oldAddr.values()])}
+          ON CONFLICT (address) DO UPDATE SET count = ${table}.count - EXCLUDED.count
         `;
-      }
-    });
-  }
-
-  async applyCurrentLocation(args: {
-    old?: DbLocationPointer;
-    new: DbLocationPointer;
-  }): Promise<void> {
-    await this.parent.sqlWriteTransaction(async sql => {
-      if (args.old && args.old.address) {
+      if (newAddr.size)
         await sql`
-          UPDATE counts_by_address SET count = count - 1 WHERE address = ${args.old.address}
+          INSERT INTO ${table} ${sql([...newAddr.values()])}
+          ON CONFLICT (address) DO UPDATE SET count = ${table}.count + EXCLUDED.count
         `;
-      }
-      if (args.new.address) {
-        await sql`
-          INSERT INTO counts_by_address ${sql({ address: args.new.address })}
-          ON CONFLICT (address) DO UPDATE SET count = counts_by_address.count + 1
-        `;
-      }
     });
   }
 

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -640,7 +640,9 @@ export class PgStore extends BasePgStore {
       `;
       if (transferGenesisIds.size)
         await sql`
-          UPDATE inscriptions SET updated_at = NOW() WHERE genesis_id IN ${sql(transferGenesisIds)}
+          UPDATE inscriptions
+          SET updated_at = NOW()
+          WHERE genesis_id IN ${sql([...transferGenesisIds])}
         `;
       // await this.brc20.insertOperation({
       //   inscription_id,

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -16,7 +16,6 @@ import {
   DbInscriptionInsert,
   DbInscriptionLocationChange,
   DbLocation,
-  DbLocationInsert,
   DbLocationPointer,
   DbLocationPointerInsert,
   DbPaginatedResult,
@@ -219,6 +218,8 @@ export class PgStore extends BasePgStore {
         }
         await this.insertInscriptions(writes);
         updatedBlockHeightMin = Math.min(updatedBlockHeightMin, event.block_identifier.index);
+        if (ENV.BRC20_BLOCK_SCAN_ENABLED)
+          await this.brc20.scanBlocks(event.block_identifier.index, event.block_identifier.index);
       }
     });
     await this.refreshMaterializedView('chain_tip');

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -142,9 +142,9 @@ export type DbInscriptionInsert = {
 };
 
 export type DbRevealInsert = {
-  inscription: DbInscriptionInsert;
+  inscription?: DbInscriptionInsert;
+  recursive_refs?: string[];
   location: DbLocationInsert;
-  recursive_refs: string[];
 };
 
 export type DbInscription = {

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -138,6 +138,13 @@ export type DbInscriptionInsert = {
   sat_ordinal: PgNumeric;
   sat_rarity: string;
   sat_coinbase_height: number;
+  recursive: boolean;
+};
+
+export type DbRevealInsert = {
+  inscription: DbInscriptionInsert;
+  location: DbLocationInsert;
+  recursive_refs: string[];
 };
 
 export type DbInscription = {

--- a/tests/brc20.test.ts
+++ b/tests/brc20.test.ts
@@ -425,7 +425,6 @@ describe('BRC-20', () => {
           )
           .build()
       );
-      await db.brc20.scanBlocks();
       const response1 = await fastify.inject({
         method: 'GET',
         url: `/ordinals/brc-20/tokens?ticker=PEPE`,
@@ -499,7 +498,6 @@ describe('BRC-20', () => {
           )
           .build()
       );
-      await db.brc20.scanBlocks();
       const response1 = await fastify.inject({
         method: 'GET',
         url: `/ordinals/brc-20/tokens?ticker=PEPE`,
@@ -573,7 +571,6 @@ describe('BRC-20', () => {
           )
           .build()
       );
-      await db.brc20.scanBlocks();
       const response1 = await fastify.inject({
         method: 'GET',
         url: `/ordinals/brc-20/tokens?ticker=PEPE`,
@@ -670,7 +667,6 @@ describe('BRC-20', () => {
           )
           .build()
       );
-      await db.brc20.scanBlocks();
 
       const response1 = await fastify.inject({
         method: 'GET',
@@ -714,7 +710,6 @@ describe('BRC-20', () => {
           )
           .build()
       );
-      await db.brc20.scanBlocks(775619);
 
       const response2 = await fastify.inject({
         method: 'GET',
@@ -785,7 +780,6 @@ describe('BRC-20', () => {
           )
           .build()
       );
-      await db.brc20.scanBlocks();
       // Rollback
       await db.updateInscriptions(
         new TestChainhookPayloadBuilder()
@@ -876,7 +870,6 @@ describe('BRC-20', () => {
           )
           .build()
       );
-      await db.brc20.scanBlocks();
 
       const response2 = await fastify.inject({
         method: 'GET',
@@ -973,7 +966,6 @@ describe('BRC-20', () => {
           )
           .build()
       );
-      await db.brc20.scanBlocks();
 
       const response2 = await fastify.inject({
         method: 'GET',
@@ -1017,7 +1009,6 @@ describe('BRC-20', () => {
           )
           .build()
       );
-      await db.brc20.scanBlocks(775619);
 
       const response3 = await fastify.inject({
         method: 'GET',
@@ -1055,7 +1046,6 @@ describe('BRC-20', () => {
           )
           .build()
       );
-      await db.brc20.scanBlocks();
 
       const response2 = await fastify.inject({
         method: 'GET',
@@ -1121,7 +1111,6 @@ describe('BRC-20', () => {
           )
           .build()
       );
-      await db.brc20.scanBlocks();
 
       const response2 = await fastify.inject({
         method: 'GET',
@@ -1216,7 +1205,6 @@ describe('BRC-20', () => {
           )
           .build()
       );
-      await db.brc20.scanBlocks();
 
       const response = await fastify.inject({
         method: 'GET',
@@ -1271,7 +1259,6 @@ describe('BRC-20', () => {
           )
           .build()
       );
-      await db.brc20.scanBlocks();
 
       const response = await fastify.inject({
         method: 'GET',
@@ -1318,7 +1305,6 @@ describe('BRC-20', () => {
           )
           .build()
       );
-      await db.brc20.scanBlocks();
 
       const response = await fastify.inject({
         method: 'GET',
@@ -1381,7 +1367,6 @@ describe('BRC-20', () => {
           )
           .build()
       );
-      await db.brc20.scanBlocks();
 
       const response = await fastify.inject({
         method: 'GET',
@@ -1451,7 +1436,6 @@ describe('BRC-20', () => {
           })
           .build()
       );
-      await db.brc20.scanBlocks();
 
       const response1 = await fastify.inject({
         method: 'GET',
@@ -1575,7 +1559,6 @@ describe('BRC-20', () => {
           })
           .build()
       );
-      await db.brc20.scanBlocks();
 
       // Balances only reflect the first transfer.
       const response1 = await fastify.inject({

--- a/tests/brc20.test.ts
+++ b/tests/brc20.test.ts
@@ -425,6 +425,7 @@ describe('BRC-20', () => {
           )
           .build()
       );
+      await db.brc20.scanBlocks();
       const response1 = await fastify.inject({
         method: 'GET',
         url: `/ordinals/brc-20/tokens?ticker=PEPE`,
@@ -498,6 +499,7 @@ describe('BRC-20', () => {
           )
           .build()
       );
+      await db.brc20.scanBlocks();
       const response1 = await fastify.inject({
         method: 'GET',
         url: `/ordinals/brc-20/tokens?ticker=PEPE`,
@@ -571,6 +573,7 @@ describe('BRC-20', () => {
           )
           .build()
       );
+      await db.brc20.scanBlocks();
       const response1 = await fastify.inject({
         method: 'GET',
         url: `/ordinals/brc-20/tokens?ticker=PEPE`,
@@ -667,6 +670,7 @@ describe('BRC-20', () => {
           )
           .build()
       );
+      await db.brc20.scanBlocks();
 
       const response1 = await fastify.inject({
         method: 'GET',
@@ -710,6 +714,7 @@ describe('BRC-20', () => {
           )
           .build()
       );
+      await db.brc20.scanBlocks(775619);
 
       const response2 = await fastify.inject({
         method: 'GET',
@@ -780,6 +785,7 @@ describe('BRC-20', () => {
           )
           .build()
       );
+      await db.brc20.scanBlocks();
       // Rollback
       await db.updateInscriptions(
         new TestChainhookPayloadBuilder()
@@ -870,6 +876,7 @@ describe('BRC-20', () => {
           )
           .build()
       );
+      await db.brc20.scanBlocks();
 
       const response2 = await fastify.inject({
         method: 'GET',
@@ -966,6 +973,7 @@ describe('BRC-20', () => {
           )
           .build()
       );
+      await db.brc20.scanBlocks();
 
       const response2 = await fastify.inject({
         method: 'GET',
@@ -1009,6 +1017,7 @@ describe('BRC-20', () => {
           )
           .build()
       );
+      await db.brc20.scanBlocks(775619);
 
       const response3 = await fastify.inject({
         method: 'GET',
@@ -1046,6 +1055,7 @@ describe('BRC-20', () => {
           )
           .build()
       );
+      await db.brc20.scanBlocks();
 
       const response2 = await fastify.inject({
         method: 'GET',
@@ -1111,6 +1121,7 @@ describe('BRC-20', () => {
           )
           .build()
       );
+      await db.brc20.scanBlocks();
 
       const response2 = await fastify.inject({
         method: 'GET',

--- a/tests/brc20.test.ts
+++ b/tests/brc20.test.ts
@@ -35,6 +35,7 @@ describe('BRC-20', () => {
         sat_ordinal: '2000000',
         sat_rarity: 'common',
         sat_coinbase_height: 110,
+        recursive: false,
       };
       return insert;
     };
@@ -61,6 +62,7 @@ describe('BRC-20', () => {
         sat_ordinal: '2000000',
         sat_rarity: 'common',
         sat_coinbase_height: 110,
+        recursive: false,
       };
       expect(brc20FromInscription(insert)).toBeUndefined();
       insert.content_type = 'application/json';
@@ -88,6 +90,7 @@ describe('BRC-20', () => {
         sat_ordinal: '2000000',
         sat_rarity: 'common',
         sat_coinbase_height: 110,
+        recursive: false,
       };
       expect(brc20FromInscription(insert)).toBeUndefined();
     });

--- a/tests/brc20.test.ts
+++ b/tests/brc20.test.ts
@@ -1216,6 +1216,7 @@ describe('BRC-20', () => {
           )
           .build()
       );
+      await db.brc20.scanBlocks();
 
       const response = await fastify.inject({
         method: 'GET',
@@ -1240,6 +1241,53 @@ describe('BRC-20', () => {
       });
       const json2 = response2.json();
       expect(json2.results[0].available_balance).toBe('10000');
+    });
+
+    test('transfer ignored if token not found', async () => {
+      const address = 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td';
+      await deployAndMintPEPE(address);
+      await db.updateInscriptions(
+        new TestChainhookPayloadBuilder()
+          .apply()
+          .block({
+            height: 775619,
+            hash: '00000000000000000002b14f0c5dde0b2fc74d022e860696bd64f1f652756674',
+          })
+          .transaction({
+            hash: 'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47a',
+          })
+          .inscriptionRevealed(
+            brc20Reveal({
+              json: {
+                p: 'brc-20',
+                op: 'transfer',
+                tick: 'TEST', // Not found
+                amt: '2000',
+              },
+              number: 7,
+              tx_id: 'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47a',
+              address: address,
+            })
+          )
+          .build()
+      );
+      await db.brc20.scanBlocks();
+
+      const response = await fastify.inject({
+        method: 'GET',
+        url: `/ordinals/brc-20/balances/${address}`,
+      });
+      expect(response.statusCode).toBe(200);
+      const json = response.json();
+      expect(json.total).toBe(1);
+      expect(json.results).toStrictEqual([
+        {
+          available_balance: '10000',
+          overall_balance: '10000',
+          ticker: 'PEPE',
+          transferrable_balance: '0',
+        },
+      ]);
     });
 
     test('cannot transfer more than available balance', async () => {
@@ -1270,6 +1318,7 @@ describe('BRC-20', () => {
           )
           .build()
       );
+      await db.brc20.scanBlocks();
 
       const response = await fastify.inject({
         method: 'GET',
@@ -1332,6 +1381,7 @@ describe('BRC-20', () => {
           )
           .build()
       );
+      await db.brc20.scanBlocks();
 
       const response = await fastify.inject({
         method: 'GET',
@@ -1401,6 +1451,7 @@ describe('BRC-20', () => {
           })
           .build()
       );
+      await db.brc20.scanBlocks();
 
       const response1 = await fastify.inject({
         method: 'GET',
@@ -1524,6 +1575,7 @@ describe('BRC-20', () => {
           })
           .build()
       );
+      await db.brc20.scanBlocks();
 
       // Balances only reflect the first transfer.
       const response1 = await fastify.inject({
@@ -1550,154 +1602,6 @@ describe('BRC-20', () => {
       const json2 = response2.json();
       expect(json2.total).toBe(1);
       expect(json2.results).toStrictEqual([
-        {
-          available_balance: '9000',
-          overall_balance: '9000',
-          ticker: 'PEPE',
-          transferrable_balance: '0',
-        },
-      ]);
-    });
-
-    test('balance transfer gap fill applied correctly', async () => {
-      const address = 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td';
-      const address2 = '3QNjwPDRafjBm9XxJpshgk3ksMJh3TFxTU';
-      await deployAndMintPEPE(address);
-      await db.updateInscriptions(
-        new TestChainhookPayloadBuilder()
-          .apply()
-          .block({
-            height: 775640,
-            hash: '00000000000000000002b14f0c5dde0b2fc74d022e860696bd64f1f652756674',
-          })
-          .transaction({
-            hash: 'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47a',
-          })
-          .inscriptionRevealed(
-            brc20Reveal({
-              json: {
-                p: 'brc-20',
-                op: 'transfer',
-                tick: 'PEPE',
-                amt: '9000',
-              },
-              number: 7,
-              tx_id: 'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47a',
-              address: address,
-            })
-          )
-          .build()
-      );
-
-      // Make the first seen transfer
-      await db.updateInscriptions(
-        new TestChainhookPayloadBuilder()
-          .apply()
-          .block({
-            height: 775651,
-            hash: '00000000000000000003feae13d107f0f2c4fb4dd08fb2a8b1ab553512e77f03',
-          })
-          .transaction({
-            hash: 'ce32d47452a4dfae6510fd283e1cec587c5cac217dec09ac4b01541adc86cd34',
-          })
-          .inscriptionTransferred({
-            inscription_id: 'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47ai0',
-            updated_address: address2,
-            satpoint_pre_transfer:
-              '7edaa48337a94da327b6262830505f116775a32db5ad4ad46e87ecea33f21bac:0:0',
-            satpoint_post_transfer:
-              'ce32d47452a4dfae6510fd283e1cec587c5cac217dec09ac4b01541adc86cd34:0:0',
-            post_transfer_output_value: null,
-            tx_index: 0,
-          })
-          .build()
-      );
-      const response1 = await fastify.inject({
-        method: 'GET',
-        url: `/ordinals/brc-20/balances/${address}`,
-      });
-      expect(response1.statusCode).toBe(200);
-      const json1 = response1.json();
-      expect(json1.total).toBe(1);
-      expect(json1.results).toStrictEqual([
-        {
-          available_balance: '1000',
-          overall_balance: '1000',
-          ticker: 'PEPE',
-          transferrable_balance: '0',
-        },
-      ]);
-      const response2 = await fastify.inject({
-        method: 'GET',
-        url: `/ordinals/brc-20/balances/${address2}`,
-      });
-      expect(response2.statusCode).toBe(200);
-      const json2 = response2.json();
-      expect(json2.total).toBe(1);
-      expect(json2.results).toStrictEqual([
-        {
-          available_balance: '9000',
-          overall_balance: '9000',
-          ticker: 'PEPE',
-          transferrable_balance: '0',
-        },
-      ]);
-
-      // Oops, turns out there was a gap fill with another transfer first
-      await db.updateInscriptions(
-        new TestChainhookPayloadBuilder()
-          .apply()
-          .block({
-            height: 775645,
-            hash: '00000000000000000003feae13d107f0f2c4fb4dd08fb2a8b1ab553512e77f03',
-          })
-          .transaction({
-            hash: '7edaa48337a94da327b6262830505f116775a32db5ad4ad46e87ecea33f21bac',
-          })
-          .inscriptionTransferred({
-            inscription_id: 'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47ai0',
-            updated_address: 'bc1q6uwuet65rm6xvlz7ztw2gvdmmay5uaycu03mqz',
-            satpoint_pre_transfer:
-              'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47a:0:0',
-            satpoint_post_transfer:
-              '7edaa48337a94da327b6262830505f116775a32db5ad4ad46e87ecea33f21bac:0:0',
-            post_transfer_output_value: null,
-            tx_index: 0,
-          })
-          .build()
-      );
-      const response1b = await fastify.inject({
-        method: 'GET',
-        url: `/ordinals/brc-20/balances/${address}`,
-      });
-      expect(response1b.statusCode).toBe(200);
-      const json1b = response1b.json();
-      expect(json1b.total).toBe(1);
-      expect(json1b.results).toStrictEqual([
-        {
-          available_balance: '1000',
-          overall_balance: '1000',
-          ticker: 'PEPE',
-          transferrable_balance: '0',
-        },
-      ]);
-      // No movements at all for this address.
-      const response2b = await fastify.inject({
-        method: 'GET',
-        url: `/ordinals/brc-20/balances/${address2}`,
-      });
-      expect(response2b.statusCode).toBe(200);
-      const json2b = response2b.json();
-      expect(json2b.total).toBe(0);
-      // This address is the one that should have the balance.
-      const response3 = await fastify.inject({
-        method: 'GET',
-        url: `/ordinals/brc-20/balances/bc1q6uwuet65rm6xvlz7ztw2gvdmmay5uaycu03mqz`,
-      });
-      expect(response3.statusCode).toBe(200);
-      const json3 = response3.json();
-      expect(json3.total).toBe(1);
-      expect(json3.results).toStrictEqual([
         {
           available_balance: '9000',
           overall_balance: '9000',


### PR DESCRIPTION
* Batch inscription inserts so they are all inserted in one query per block, plus as few queries as possible when doing other calculations (location pointers, count accumulation, etc.)
* Separate BRC-20 processing into another process detached from block ingestion so we can trigger externally
* Create Admin RPC to quickly trigger a BRC-20 re-scan