### PR TITLE
feat: add tx_count sorting to tokens endpoint

### DIFF
--- a/migrations/1693923781000_brc20-counts-by-tx-volume.ts
+++ b/migrations/1693923781000_brc20-counts-by-tx-volume.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.addColumn('brc20_deploys', {
+    tx_count: {
+      type: 'numeric',
+      default: 0,
+    },
+  });
+  pgm.sql(`
+    UPDATE brc20_deploys AS d
+    SET tx_count = (
+      SELECT COALESCE(COUNT(*), 0) AS tx_count
+      FROM brc20_events
+      WHERE brc20_deploy_id = d.id
+    )
+  `);
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropColumn('brc20_deploys', 'tx_count');
+}

--- a/src/api/routes/brc20.ts
+++ b/src/api/routes/brc20.ts
@@ -6,6 +6,7 @@ import { Server } from 'http';
 import {
   AddressParam,
   BlockHeightParam,
+  Brc20TokensOrderByParam,
   Brc20ActivityResponseSchema,
   Brc20BalanceResponseSchema,
   Brc20HolderResponseSchema,
@@ -46,6 +47,8 @@ export const Brc20Routes: FastifyPluginCallback<
         tags: ['BRC-20'],
         querystring: Type.Object({
           ticker: Type.Optional(Brc20TickersParam),
+          // Sorting
+          order_by: Type.Optional(Brc20TokensOrderByParam),
           // Pagination
           offset: Type.Optional(OffsetParam),
           limit: Type.Optional(LimitParam),
@@ -62,6 +65,7 @@ export const Brc20Routes: FastifyPluginCallback<
         limit,
         offset,
         ticker: request.query.ticker,
+        order_by: request.query.order_by,
       });
       await reply.send({
         limit,

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -215,6 +215,15 @@ export const Brc20OperationParam = Type.Union(
 
 export const Brc20OperationsParam = Type.Array(Brc20OperationParam);
 
+export enum Brc20TokenOrderBy {
+  tx_count = 'tx_count',
+  index = 'index',
+}
+export const Brc20TokensOrderByParam = Type.Enum(Brc20TokenOrderBy, {
+  title: 'Order By',
+  description: 'Parameter to order results by',
+});
+
 export enum OrderBy {
   number = 'number',
   genesis_block_height = 'genesis_block_height',

--- a/src/pg/brc20/types.ts
+++ b/src/pg/brc20/types.ts
@@ -22,6 +22,7 @@ export type DbBrc20DeployInsert = {
   max: string;
   decimals: string;
   limit: string | null;
+  tx_count: number;
 };
 
 export type DbBrc20MintInsert = {

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -229,6 +229,9 @@ export class PgStore extends BasePgStore {
           await this.brc20.scanBlocks(event.block_identifier.index, event.block_identifier.index);
       }
     });
+    if (payload.rollback.length > 0) {
+      await this.brc20.normalizeDeployTxCounts(); // not efficient re-count, but only happens on rollbacks
+    }
     await this.refreshMaterializedView('chain_tip');
     // Skip expensive view refreshes if we're not streaming live blocks.
     if (payload.chainhook.is_streaming_blocks) {


### PR DESCRIPTION
- adds `tx_count` order by to brc20 tokens endpoint
- the normalize/rollback is just a complete re-count, but it's only done if a rollback was seen. is this a sensible approach (assuming rollbacks don't happen often and it's okay to take a performance hit?)