### PR TITLE
fix: keep count of brc-20 activity per address

### DIFF
--- a/migrations/1694797181616_brc20-counts-by-address-event.ts
+++ b/migrations/1694797181616_brc20-counts-by-address-event.ts
@@ -1,0 +1,34 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.createTable('brc20_counts_by_address_event_type', {
+    address: {
+      type: 'text',
+      notNull: true,
+      primaryKey: true,
+    },
+    deploy: {
+      type: 'bigint',
+      notNull: true,
+      default: 0,
+    },
+    mint: {
+      type: 'bigint',
+      notNull: true,
+      default: 0,
+    },
+    transfer: {
+      type: 'bigint',
+      notNull: true,
+      default: 0,
+    },
+    transfer_send: {
+      type: 'bigint',
+      notNull: true,
+      default: 0,
+    },
+  });
+}

--- a/migrations/1694797181616_brc20-counts-by-address-event.ts
+++ b/migrations/1694797181616_brc20-counts-by-address-event.ts
@@ -60,7 +60,7 @@ export function up(pgm: MigrationBuilder): void {
       FROM brc20_transfers
       WHERE to_address <> from_address
       GROUP BY to_address
-    ) ON CONFLICT (address) DO UPDATE SET transfer_send = EXCLUDED.transfer_send
+    ) ON CONFLICT (address) DO UPDATE SET transfer_send = brc20_counts_by_address_event_type.transfer_send + EXCLUDED.transfer_send
   `);
 }
 

--- a/migrations/1694797181616_brc20-counts-by-address-event.ts
+++ b/migrations/1694797181616_brc20-counts-by-address-event.ts
@@ -31,4 +31,39 @@ export function up(pgm: MigrationBuilder): void {
       default: 0,
     },
   });
+  pgm.sql(`
+    INSERT INTO brc20_counts_by_address_event_type (address, deploy) (
+      SELECT address, COUNT(*) AS deploy FROM brc20_deploys GROUP BY address
+    ) ON CONFLICT (address) DO UPDATE SET deploy = EXCLUDED.deploy
+  `);
+  pgm.sql(`
+    INSERT INTO brc20_counts_by_address_event_type (address, mint) (
+      SELECT address, COUNT(*) AS mint FROM brc20_mints GROUP BY address
+    ) ON CONFLICT (address) DO UPDATE SET mint = EXCLUDED.mint
+  `);
+  pgm.sql(`
+    INSERT INTO brc20_counts_by_address_event_type (address, transfer) (
+      SELECT from_address AS address, COUNT(*) AS transfer FROM brc20_transfers GROUP BY from_address
+    ) ON CONFLICT (address) DO UPDATE SET transfer = EXCLUDED.transfer
+  `);
+  pgm.sql(`
+    INSERT INTO brc20_counts_by_address_event_type (address, transfer_send) (
+      SELECT from_address AS address, COUNT(*) AS transfer_send
+      FROM brc20_transfers
+      WHERE to_address IS NOT NULL
+      GROUP BY from_address
+    ) ON CONFLICT (address) DO UPDATE SET transfer_send = EXCLUDED.transfer_send
+  `);
+  pgm.sql(`
+    INSERT INTO brc20_counts_by_address_event_type (address, transfer_send) (
+      SELECT to_address AS address, COUNT(*) AS transfer_send
+      FROM brc20_transfers
+      WHERE to_address <> from_address
+      GROUP BY to_address
+    ) ON CONFLICT (address) DO UPDATE SET transfer_send = EXCLUDED.transfer_send
+  `);
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropTable('brc20_counts_by_address_event_type');
 }

--- a/src/api/util/helpers.ts
+++ b/src/api/util/helpers.ts
@@ -2,6 +2,7 @@ import BigNumber from 'bignumber.js';
 import {
   DbBrc20Activity,
   DbBrc20Balance,
+  DbBrc20EventOperation,
   DbBrc20Holder,
   DbBrc20Token,
   DbBrc20TokenWithSupply,
@@ -153,7 +154,7 @@ export function parseBrc20Activities(items: DbBrc20Activity[]): Brc20ActivityRes
       timestamp: i.timestamp.valueOf(),
     };
     switch (i.operation) {
-      case 'deploy': {
+      case DbBrc20EventOperation.deploy: {
         return {
           ...activity,
           deploy: {
@@ -163,7 +164,7 @@ export function parseBrc20Activities(items: DbBrc20Activity[]): Brc20ActivityRes
           },
         };
       }
-      case 'mint': {
+      case DbBrc20EventOperation.mint: {
         return {
           ...activity,
           mint: {
@@ -171,14 +172,14 @@ export function parseBrc20Activities(items: DbBrc20Activity[]): Brc20ActivityRes
           },
         };
       }
-      case 'transfer': {
+      case DbBrc20EventOperation.transfer: {
         const [amount, from_address] = i.transfer_data.split(';');
         return {
           ...activity,
           transfer: { amount: decimals(amount, i.deploy_decimals), from_address },
         };
       }
-      case 'transfer_send': {
+      case DbBrc20EventOperation.transferSend: {
         const [amount, from_address, to_address] = i.transfer_data.split(';');
         return {
           ...activity,

--- a/src/pg/brc20/brc20-pg-store.ts
+++ b/src/pg/brc20/brc20-pg-store.ts
@@ -4,6 +4,7 @@ import { hexToBuffer } from '../../api/util/helpers';
 import { DbInscription, DbInscriptionIndexPaging, DbLocation, DbPaginatedResult } from '../types';
 import {
   BRC20_DEPLOYS_COLUMNS,
+  BRC20_OPERATIONS,
   DbBrc20Activity,
   DbBrc20Balance,
   DbBrc20BalanceTypeId,
@@ -156,6 +157,11 @@ export class Brc20PgStore extends BasePgStoreModule {
                     trans_balance = trans_balance - (SELECT amount FROM validated_transfer)
                   WHERE brc20_deploy_id = (SELECT brc20_deploy_id FROM validated_transfer)
                     AND address = (SELECT from_address FROM validated_transfer)
+                ),
+                address_event_type_count_increase AS (
+                  INSERT INTO brc20_counts_by_address_event_type (address, transfer_send)
+                  (SELECT from_address, 1 FROM validated_transfer)
+                  ON CONFLICT (address) DO UPDATE SET transfer_send = brc20_counts_by_address_event_type.transfer_send + EXCLUDED.transfer_send
                 )
               `
             : sql`
@@ -174,6 +180,16 @@ export class Brc20PgStore extends BasePgStoreModule {
                   ON CONFLICT ON CONSTRAINT brc20_total_balances_unique DO UPDATE SET
                     avail_balance = brc20_total_balances.avail_balance + EXCLUDED.avail_balance,
                     total_balance = brc20_total_balances.total_balance + EXCLUDED.total_balance
+                ),
+                address_event_type_count_increase_from AS (
+                  INSERT INTO brc20_counts_by_address_event_type (address, transfer_send)
+                  (SELECT from_address, 1 FROM validated_transfer)
+                  ON CONFLICT (address) DO UPDATE SET transfer_send = brc20_counts_by_address_event_type.transfer_send + EXCLUDED.transfer_send
+                ),
+                address_event_type_count_increase_to AS (
+                  INSERT INTO brc20_counts_by_address_event_type (address, transfer_send)
+                  (SELECT ${toAddress}, 1 FROM validated_transfer)
+                  ON CONFLICT (address) DO UPDATE SET transfer_send = brc20_counts_by_address_event_type.transfer_send + EXCLUDED.transfer_send
                 )
               `
         }, deploy_update AS (
@@ -222,6 +238,11 @@ export class Brc20PgStore extends BasePgStoreModule {
         INSERT INTO brc20_counts_by_event_type (event_type, count)
         (SELECT 'deploy', COALESCE(COUNT(*), 0) FROM deploy_insert)
         ON CONFLICT (event_type) DO UPDATE SET count = brc20_counts_by_event_type.count + EXCLUDED.count
+      ),
+      address_event_type_count_increase AS (
+        INSERT INTO brc20_counts_by_address_event_type (address, deploy)
+        (SELECT ${deploy.location.address}, COALESCE(COUNT(*), 0) FROM deploy_insert)
+        ON CONFLICT (address) DO UPDATE SET deploy = brc20_counts_by_address_event_type.deploy + EXCLUDED.deploy
       ),
       token_count_increase AS (
         INSERT INTO brc20_counts_by_tokens (token_type, count)
@@ -296,6 +317,11 @@ export class Brc20PgStore extends BasePgStoreModule {
         INSERT INTO brc20_counts_by_event_type (event_type, count)
         (SELECT 'mint', COALESCE(COUNT(*), 0) FROM validated_mint)
         ON CONFLICT (event_type) DO UPDATE SET count = brc20_counts_by_event_type.count + EXCLUDED.count
+      ),
+      address_event_type_count_increase AS (
+        INSERT INTO brc20_counts_by_address_event_type (address, mint)
+        (SELECT ${mint.location.address}, COALESCE(COUNT(*), 0) FROM validated_mint)
+        ON CONFLICT (address) DO UPDATE SET mint = brc20_counts_by_address_event_type.mint + EXCLUDED.mint
       )
       INSERT INTO brc20_events (operation, inscription_id, genesis_location_id, brc20_deploy_id, mint_id) (
         SELECT 'mint', ${mint.location.inscription_id}, ${mint.location.id}, brc20_deploy_id, id
@@ -363,6 +389,11 @@ export class Brc20PgStore extends BasePgStoreModule {
         INSERT INTO brc20_counts_by_event_type (event_type, count)
         (SELECT 'transfer', COALESCE(COUNT(*), 0) FROM validated_transfer)
         ON CONFLICT (event_type) DO UPDATE SET count = brc20_counts_by_event_type.count + EXCLUDED.count
+      ),
+      address_event_type_count_increase AS (
+        INSERT INTO brc20_counts_by_address_event_type (address, transfer)
+        (SELECT ${transfer.location.address}, COALESCE(COUNT(*), 0) FROM validated_transfer)
+        ON CONFLICT (address) DO UPDATE SET transfer = brc20_counts_by_address_event_type.transfer + EXCLUDED.transfer
       )
       INSERT INTO brc20_events (operation, inscription_id, genesis_location_id, brc20_deploy_id, transfer_id) (
         SELECT 'transfer', ${transfer.location.inscription_id}, ${transfer.location.id}, brc20_deploy_id, id
@@ -420,6 +451,11 @@ export class Brc20PgStore extends BasePgStoreModule {
         UPDATE brc20_counts_by_event_type
         SET count = count - 1
         WHERE event_type = 'deploy'
+      ),
+      decrease_address_event_count AS (
+        UPDATE brc20_counts_by_address_event_type
+        SET deploy = deploy - 1
+        WHERE address = (SELECT address FROM locations WHERE id = ${activity.genesis_location_id})
       )
       UPDATE brc20_counts_by_tokens
       SET count = count - 1
@@ -445,6 +481,11 @@ export class Brc20PgStore extends BasePgStoreModule {
         UPDATE brc20_counts_by_event_type
         SET count = count - 1
         WHERE event_type = 'mint'
+      ),
+      decrease_address_event_count AS (
+        UPDATE brc20_counts_by_address_event_type
+        SET mint = mint - 1
+        WHERE address = (SELECT address FROM locations WHERE id = ${activity.genesis_location_id})
       )
       UPDATE brc20_total_balances SET
         avail_balance = avail_balance - (SELECT avail_balance FROM minted_balance),
@@ -468,6 +509,11 @@ export class Brc20PgStore extends BasePgStoreModule {
         SET count = count - 1
         WHERE event_type = 'transfer'
       ),
+      decrease_address_event_count AS (
+        UPDATE brc20_counts_by_address_event_type
+        SET transfer = transfer - 1
+        WHERE address = (SELECT address FROM locations WHERE id = ${activity.genesis_location_id})
+      ),
       decrease_tx_count AS (
         UPDATE brc20_deploys
         SET tx_count = tx_count - 1
@@ -482,40 +528,82 @@ export class Brc20PgStore extends BasePgStoreModule {
   }
 
   private async rollBackTransferSend(activity: DbBrc20TransferEvent): Promise<void> {
-    await this.sql`
-      WITH sent_balance_from AS (
-        SELECT address, trans_balance
-        FROM brc20_balances
-        WHERE inscription_id = ${activity.inscription_id} AND type = ${DbBrc20BalanceTypeId.transferFrom}
-      ),
-      sent_balance_to AS (
-        SELECT address, avail_balance
-        FROM brc20_balances
-        WHERE inscription_id = ${activity.inscription_id} AND type = ${DbBrc20BalanceTypeId.transferTo}
-      ),
-      decrease_event_count AS (
-        UPDATE brc20_counts_by_event_type
-        SET count = count - 1
-        WHERE event_type = 'transfer_send'
-      ),
-      decrease_tx_count AS (
+    await this.sqlWriteTransaction(async sql => {
+      // Get the sender/receiver address for this transfer. We need to get this in a separate query
+      // to know if we should alter the write query to accomodate a "return to sender" scenario.
+      const addressRes = await sql<{ returned_to_sender: boolean }[]>`
+        SELECT from_address = to_address AS returned_to_sender
+        FROM brc20_transfers
+        WHERE inscription_id = ${activity.inscription_id}
+      `;
+      if (addressRes.count === 0) return;
+      const returnedToSender = addressRes[0].returned_to_sender;
+      await sql`
+        WITH sent_balance_from AS (
+          SELECT address, trans_balance
+          FROM brc20_balances
+          WHERE inscription_id = ${activity.inscription_id}
+          AND type = ${DbBrc20BalanceTypeId.transferFrom}
+        ),
+        sent_balance_to AS (
+          SELECT address, avail_balance
+          FROM brc20_balances
+          WHERE inscription_id = ${activity.inscription_id}
+          AND type = ${DbBrc20BalanceTypeId.transferTo}
+        ),
+        decrease_event_count AS (
+          UPDATE brc20_counts_by_event_type
+          SET count = count - 1
+          WHERE event_type = 'transfer_send'
+        ),
+        ${
+          returnedToSender
+            ? sql`
+                decrease_address_event_count AS (
+                  UPDATE brc20_counts_by_address_event_type
+                  SET transfer_send = transfer_send - 1
+                  WHERE address = (SELECT address FROM sent_balance_from)
+                ),
+                undo_sent_balance AS (
+                  UPDATE brc20_total_balances SET
+                    trans_balance = trans_balance + (SELECT trans_balance FROM sent_balance_from),
+                    avail_balance = avail_balance - (SELECT trans_balance FROM sent_balance_from)
+                  WHERE address = (SELECT address FROM sent_balance_from)
+                    AND brc20_deploy_id = ${activity.brc20_deploy_id}
+                )
+              `
+            : sql`
+                decrease_address_event_count_from AS (
+                  UPDATE brc20_counts_by_address_event_type
+                  SET transfer_send = transfer_send - 1
+                  WHERE address = (SELECT address FROM sent_balance_from)
+                ),
+                decrease_address_event_count_to AS (
+                  UPDATE brc20_counts_by_address_event_type
+                  SET transfer_send = transfer_send - 1
+                  WHERE address = (SELECT address FROM sent_balance_to)
+                ),
+                undo_sent_balance_from AS (
+                  UPDATE brc20_total_balances SET
+                    trans_balance = trans_balance - (SELECT trans_balance FROM sent_balance_from),
+                    total_balance = total_balance - (SELECT trans_balance FROM sent_balance_from)
+                  WHERE address = (SELECT address FROM sent_balance_from)
+                    AND brc20_deploy_id = ${activity.brc20_deploy_id}
+                ),
+                undo_sent_balance_to AS (
+                  UPDATE brc20_total_balances SET
+                    avail_balance = avail_balance - (SELECT avail_balance FROM sent_balance_to),
+                    total_balance = total_balance - (SELECT avail_balance FROM sent_balance_to)
+                  WHERE address = (SELECT address FROM sent_balance_to)
+                    AND brc20_deploy_id = ${activity.brc20_deploy_id}
+                )
+              `
+        }
         UPDATE brc20_deploys
         SET tx_count = tx_count - 1
         WHERE id = ${activity.brc20_deploy_id}
-      ),
-      undo_sent_balance_from AS (
-        UPDATE brc20_total_balances SET
-          trans_balance = trans_balance - (SELECT trans_balance FROM sent_balance_from),
-          total_balance = total_balance - (SELECT trans_balance FROM sent_balance_from)
-        WHERE address = (SELECT address FROM sent_balance_from)
-          AND brc20_deploy_id = ${activity.brc20_deploy_id}
-      )
-      UPDATE brc20_total_balances SET
-        avail_balance = avail_balance - (SELECT avail_balance FROM sent_balance_to),
-        total_balance = total_balance - (SELECT avail_balance FROM sent_balance_to)
-      WHERE address = (SELECT address FROM sent_balance_to)
-        AND brc20_deploy_id = ${activity.brc20_deploy_id}
-    `;
+      `;
+    });
   }
 
   async getTokens(
@@ -670,15 +758,26 @@ export class Brc20PgStore extends BasePgStoreModule {
     }
   ): Promise<DbPaginatedResult<DbBrc20Activity>> {
     objRemoveUndefinedValues(filters);
+    const filterLength = Object.keys(filters).length;
+    // Do we need a specific result count such as total activity or activity per address?
+    const needsGlobalEventCount = filterLength === 0 || (filterLength === 1 && filters.operation);
+    const needsAddressEventCount =
+      (filterLength === 1 && filters.address) ||
+      (filterLength === 2 && filters.operation && filters.address);
+    // Which operations do we need if we're filtering by address?
+    const sanitizedOperations: DbBrc20EventOperation[] = [];
+    for (const i of filters.operation ?? BRC20_OPERATIONS)
+      if (BRC20_OPERATIONS.includes(i)) sanitizedOperations?.push(i as DbBrc20EventOperation);
+    // Which tickers are we filtering for?
     const tickerConditions = this.sqlOr(
       filters.ticker?.map(t => this.sql`d.ticker_lower = LOWER(${t})`)
     );
-    const isGlobalCount =
-      Object.keys(filters).length === 0 || (Object.keys(filters).length === 1 && filters.operation);
+
     const results = await this.sql<(DbBrc20Activity & { total: number })[]>`
-      ${
-        isGlobalCount
-          ? this.sql`WITH global_count AS (
+      WITH event_count AS (${
+        // Select count from the correct count cache table.
+        needsGlobalEventCount
+          ? this.sql`
               SELECT COALESCE(SUM(count), 0) AS count
               FROM brc20_counts_by_event_type
               ${
@@ -686,9 +785,15 @@ export class Brc20PgStore extends BasePgStoreModule {
                   ? this.sql`WHERE event_type IN ${this.sql(filters.operation)}`
                   : this.sql``
               }
-            )`
-          : this.sql``
-      }
+            `
+          : needsAddressEventCount
+          ? this.sql`
+              SELECT COALESCE(${this.sql.unsafe(sanitizedOperations.join('+'))}, 0) AS count
+              FROM brc20_counts_by_address_event_type
+              WHERE address = ${filters.address}
+            `
+          : this.sql`SELECT NULL AS count`
+      })
       SELECT
         e.operation,
         d.ticker,
@@ -706,7 +811,9 @@ export class Brc20PgStore extends BasePgStoreModule {
         (SELECT amount FROM brc20_mints WHERE id = e.mint_id) AS mint_amount,
         (SELECT amount || ';' || from_address || ';' || COALESCE(to_address, '') FROM brc20_transfers WHERE id = e.transfer_id) AS transfer_data,
         ${
-          isGlobalCount ? this.sql`(SELECT count FROM global_count)` : this.sql`COUNT(*) OVER()`
+          needsGlobalEventCount || needsAddressEventCount
+            ? this.sql`(SELECT count FROM event_count)`
+            : this.sql`COUNT(*) OVER()`
         } AS total
       FROM brc20_events AS e
       INNER JOIN brc20_deploys AS d ON e.brc20_deploy_id = d.id

--- a/src/pg/brc20/brc20-pg-store.ts
+++ b/src/pg/brc20/brc20-pg-store.ts
@@ -566,8 +566,8 @@ export class Brc20PgStore extends BasePgStoreModule {
                 ),
                 undo_sent_balance AS (
                   UPDATE brc20_total_balances SET
-                    trans_balance = trans_balance + (SELECT trans_balance FROM sent_balance_from),
-                    avail_balance = avail_balance - (SELECT trans_balance FROM sent_balance_from)
+                    trans_balance = trans_balance - (SELECT trans_balance FROM sent_balance_from),
+                    avail_balance = avail_balance + (SELECT trans_balance FROM sent_balance_from)
                   WHERE address = (SELECT address FROM sent_balance_from)
                     AND brc20_deploy_id = ${activity.brc20_deploy_id}
                 )

--- a/src/pg/brc20/types.ts
+++ b/src/pg/brc20/types.ts
@@ -107,7 +107,13 @@ export enum DbBrc20BalanceTypeId {
   transferTo = 3,
 }
 
-export type DbBrc20EventOperation = 'deploy' | 'mint' | 'transfer' | 'transfer_send';
+export enum DbBrc20EventOperation {
+  deploy = 'deploy',
+  mint = 'mint',
+  transfer = 'transfer',
+  transferSend = 'transfer_send',
+}
+export const BRC20_OPERATIONS = ['deploy', 'mint', 'transfer', 'transfer_send'];
 
 type BaseEvent = {
   inscription_id: string;
@@ -156,16 +162,16 @@ type BaseActivity = {
 };
 
 export type DbBrc20DeployActivity = BaseActivity & {
-  operation: 'deploy';
+  operation: DbBrc20EventOperation.deploy;
 };
 
 export type DbBrc20MintActivity = BaseActivity & {
-  operation: 'mint';
+  operation: DbBrc20EventOperation.mint;
   mint_amount: string;
 };
 
 export type DbBrc20TransferActivity = BaseActivity & {
-  operation: 'transfer' | 'transfer_send';
+  operation: DbBrc20EventOperation.transfer | DbBrc20EventOperation.transferSend;
   transfer_data: string;
 };
 

--- a/tests/brc20.test.ts
+++ b/tests/brc20.test.ts
@@ -10,6 +10,7 @@ import {
   brc20Reveal,
   incrementing,
   randomHash,
+  rollBack,
 } from './helpers';
 
 describe('BRC-20', () => {
@@ -3188,105 +3189,148 @@ describe('BRC-20', () => {
       const address = 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td';
       const address2 = '3QNjwPDRafjBm9XxJpshgk3ksMJh3TFxTU';
       await deployAndMintPEPE(address);
+
       // Transfer and send PEPE
-      await db.updateInscriptions(
-        new TestChainhookPayloadBuilder()
-          .apply()
-          .block({
-            height: 775619,
-            hash: '00000000000000000002b14f0c5dde0b2fc74d022e860696bd64f1f652756674',
+      const transferPEPE = new TestChainhookPayloadBuilder()
+        .apply()
+        .block({
+          height: 775619,
+          hash: '00000000000000000002b14f0c5dde0b2fc74d022e860696bd64f1f652756674',
+        })
+        .transaction({
+          hash: 'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47a',
+        })
+        .inscriptionRevealed(
+          brc20Reveal({
+            json: {
+              p: 'brc-20',
+              op: 'transfer',
+              tick: 'PEPE',
+              amt: '9000',
+            },
+            number: 7,
+            tx_id: 'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47a',
+            address: address,
           })
-          .transaction({
-            hash: 'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47a',
-          })
-          .inscriptionRevealed(
-            brc20Reveal({
-              json: {
-                p: 'brc-20',
-                op: 'transfer',
-                tick: 'PEPE',
-                amt: '9000',
-              },
-              number: 7,
-              tx_id: 'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47a',
-              address: address,
-            })
-          )
-          .build()
-      );
-      await db.updateInscriptions(
-        new TestChainhookPayloadBuilder()
-          .apply()
-          .block({
-            height: 775620,
-            hash: '000000000000000000016ddf56d0fe72476165acee9500d48d3e2aaf8412f489',
-          })
-          .transaction({
-            hash: '7edaa48337a94da327b6262830505f116775a32db5ad4ad46e87ecea33f21bac',
-          })
-          .inscriptionTransferred({
-            inscription_id: 'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47ai0',
-            updated_address: address2,
-            satpoint_pre_transfer:
-              'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47a:0:0',
-            satpoint_post_transfer:
-              '7edaa48337a94da327b6262830505f116775a32db5ad4ad46e87ecea33f21bac:0:0',
-            post_transfer_output_value: null,
-            tx_index: 0,
-          })
-          .build()
-      );
+        )
+        .build();
+      await db.updateInscriptions(transferPEPE);
+      const sendPEPE = new TestChainhookPayloadBuilder()
+        .apply()
+        .block({
+          height: 775620,
+          hash: '000000000000000000016ddf56d0fe72476165acee9500d48d3e2aaf8412f489',
+        })
+        .transaction({
+          hash: '7edaa48337a94da327b6262830505f116775a32db5ad4ad46e87ecea33f21bac',
+        })
+        .inscriptionTransferred({
+          inscription_id: 'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47ai0',
+          updated_address: address2,
+          satpoint_pre_transfer:
+            'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47a:0:0',
+          satpoint_post_transfer:
+            '7edaa48337a94da327b6262830505f116775a32db5ad4ad46e87ecea33f21bac:0:0',
+          post_transfer_output_value: null,
+          tx_index: 0,
+        })
+        .build();
+      await db.updateInscriptions(sendPEPE);
       // Deploy and mint 🔥 token
-      await db.updateInscriptions(
-        new TestChainhookPayloadBuilder()
-          .apply()
-          .block({
-            height: 775621,
-            hash: '000000000000000000033b0b78ff68c5767109f45ee42696bd4db9b2845a7ea8',
+      const deployFIRE = new TestChainhookPayloadBuilder()
+        .apply()
+        .block({
+          height: 775621,
+          hash: '000000000000000000033b0b78ff68c5767109f45ee42696bd4db9b2845a7ea8',
+        })
+        .transaction({
+          hash: '8354e85e87fa2df8b3a06ec0b9d395559b95174530cb19447fc4df5f6d4ca84d',
+        })
+        .inscriptionRevealed(
+          brc20Reveal({
+            json: {
+              p: 'brc-20',
+              op: 'deploy',
+              tick: '🔥',
+              max: '1000',
+            },
+            number: 50,
+            tx_id: '8354e85e87fa2df8b3a06ec0b9d395559b95174530cb19447fc4df5f6d4ca84d',
+            address: address,
           })
-          .transaction({
-            hash: '8354e85e87fa2df8b3a06ec0b9d395559b95174530cb19447fc4df5f6d4ca84d',
+        )
+        .build();
+      await db.updateInscriptions(deployFIRE);
+      const mintFIRE = new TestChainhookPayloadBuilder()
+        .apply()
+        .block({
+          height: 775622,
+          hash: '00000000000000000001f022fadbd930ccf6acbe00a07626e3a0898fb5799bc9',
+        })
+        .transaction({
+          hash: '81f4ee2c247c5f5c0d3a6753fef706df410ea61c2aa6d370003b98beb041b887',
+        })
+        .inscriptionRevealed(
+          brc20Reveal({
+            json: {
+              p: 'brc-20',
+              op: 'mint',
+              tick: '🔥',
+              amt: '500',
+            },
+            number: 60,
+            tx_id: '81f4ee2c247c5f5c0d3a6753fef706df410ea61c2aa6d370003b98beb041b887',
+            address: address,
           })
-          .inscriptionRevealed(
-            brc20Reveal({
-              json: {
-                p: 'brc-20',
-                op: 'deploy',
-                tick: '🔥',
-                max: '1000',
-              },
-              number: 50,
-              tx_id: '8354e85e87fa2df8b3a06ec0b9d395559b95174530cb19447fc4df5f6d4ca84d',
-              address: address,
-            })
-          )
-          .build()
-      );
-      await db.updateInscriptions(
-        new TestChainhookPayloadBuilder()
-          .apply()
-          .block({
-            height: 775622,
-            hash: '00000000000000000001f022fadbd930ccf6acbe00a07626e3a0898fb5799bc9',
+        )
+        .build();
+      await db.updateInscriptions(mintFIRE);
+      // Transfer and send 🔥 to self
+      const transferFIRE = new TestChainhookPayloadBuilder()
+        .apply()
+        .block({
+          height: 775623,
+          hash: '00000000000000000002bfcb8860d4730fcd3986b026b9629ea6106fe2cb9197',
+        })
+        .transaction({
+          hash: 'c1c7f1d5c10a30605a8a5285ca3465a4f75758ed9b7f201e5ef62727e179966f',
+        })
+        .inscriptionRevealed(
+          brc20Reveal({
+            json: {
+              p: 'brc-20',
+              op: 'transfer',
+              tick: '🔥',
+              amt: '100',
+            },
+            number: 90,
+            tx_id: 'c1c7f1d5c10a30605a8a5285ca3465a4f75758ed9b7f201e5ef62727e179966f',
+            address: address,
           })
-          .transaction({
-            hash: '81f4ee2c247c5f5c0d3a6753fef706df410ea61c2aa6d370003b98beb041b887',
-          })
-          .inscriptionRevealed(
-            brc20Reveal({
-              json: {
-                p: 'brc-20',
-                op: 'mint',
-                tick: '🔥',
-                amt: '500',
-              },
-              number: 60,
-              tx_id: '81f4ee2c247c5f5c0d3a6753fef706df410ea61c2aa6d370003b98beb041b887',
-              address: address,
-            })
-          )
-          .build()
-      );
+        )
+        .build();
+      await db.updateInscriptions(transferFIRE);
+      const sendFIRE = new TestChainhookPayloadBuilder()
+        .apply()
+        .block({
+          height: 775624,
+          hash: '00000000000000000003cbbe6d21f03f531cee6e96f33f4a8277a3d8bce5c759',
+        })
+        .transaction({
+          hash: 'a00d01a3e772ce2219ddf3fe2fe4053be071262d9594f11f018fdada7179ae2d',
+        })
+        .inscriptionTransferred({
+          inscription_id: 'c1c7f1d5c10a30605a8a5285ca3465a4f75758ed9b7f201e5ef62727e179966fi0',
+          updated_address: address, // To self
+          satpoint_pre_transfer:
+            'c1c7f1d5c10a30605a8a5285ca3465a4f75758ed9b7f201e5ef62727e179966f:0:0',
+          satpoint_post_transfer:
+            'a00d01a3e772ce2219ddf3fe2fe4053be071262d9594f11f018fdada7179ae2d:0:0',
+          post_transfer_output_value: null,
+          tx_index: 0,
+        })
+        .build();
+      await db.updateInscriptions(sendFIRE);
 
       // Check counts, total minted, holders, events.
       let request = await fastify.inject({
@@ -3346,9 +3390,9 @@ describe('BRC-20', () => {
         url: `/ordinals/brc-20/activity`,
       });
       json = request.json();
-      expect(json.total).toBe(6);
-      expect(json.results).toHaveLength(6);
-      expect(json.results[0].operation).toBe('mint');
+      expect(json.total).toBe(8);
+      expect(json.results).toHaveLength(8);
+      expect(json.results[0].operation).toBe('transfer_send');
       request = await fastify.inject({
         method: 'GET',
         url: `/ordinals/brc-20/activity?block_height=775622`,
@@ -3357,33 +3401,65 @@ describe('BRC-20', () => {
       expect(json.total).toBe(1);
       expect(json.results).toHaveLength(1);
       expect(json.results[0].operation).toBe('mint');
+      request = await fastify.inject({
+        method: 'GET',
+        url: `/ordinals/brc-20/activity?address=${address}`,
+      });
+      json = request.json();
+      expect(json.total).toBe(8);
+      expect(json.results).toHaveLength(8);
+      expect(json.results[0].operation).toBe('transfer_send');
 
-      // Rollback 1: 🔥 is un-minted
-      await db.updateInscriptions(
-        new TestChainhookPayloadBuilder()
-          .rollback()
-          .block({
-            height: 775622,
-            hash: '00000000000000000001f022fadbd930ccf6acbe00a07626e3a0898fb5799bc9',
-          })
-          .transaction({
-            hash: '81f4ee2c247c5f5c0d3a6753fef706df410ea61c2aa6d370003b98beb041b887',
-          })
-          .inscriptionRevealed(
-            brc20Reveal({
-              json: {
-                p: 'brc-20',
-                op: 'mint',
-                tick: '🔥',
-                amt: '500',
-              },
-              number: 60,
-              tx_id: '81f4ee2c247c5f5c0d3a6753fef706df410ea61c2aa6d370003b98beb041b887',
-              address: address,
-            })
-          )
-          .build()
-      );
+      // Rollback: 🔥 is un-sent
+      await db.updateInscriptions(rollBack(sendFIRE));
+      request = await fastify.inject({
+        method: 'GET',
+        url: `/ordinals/brc-20/balances/${address}`,
+      });
+      json = request.json();
+      expect(json.total).toBe(2);
+      expect(json.results).toHaveLength(2);
+      expect(json.results[1]).toStrictEqual({
+        ticker: '🔥',
+        available_balance: '400.000000000000000000',
+        transferrable_balance: '100.000000000000000000',
+        overall_balance: '500.000000000000000000',
+      });
+      request = await fastify.inject({
+        method: 'GET',
+        url: `/ordinals/brc-20/activity?address=${address}`,
+      });
+      json = request.json();
+      expect(json.total).toBe(7);
+      expect(json.results).toHaveLength(7);
+      expect(json.results[0].operation).toBe('transfer');
+
+      // Rollback: 🔥 is un-transferred
+      await db.updateInscriptions(rollBack(transferFIRE));
+      request = await fastify.inject({
+        method: 'GET',
+        url: `/ordinals/brc-20/balances/${address}`,
+      });
+      json = request.json();
+      expect(json.total).toBe(2);
+      expect(json.results).toHaveLength(2);
+      expect(json.results[1]).toStrictEqual({
+        ticker: '🔥',
+        available_balance: '500.000000000000000000',
+        transferrable_balance: '0.000000000000000000',
+        overall_balance: '500.000000000000000000',
+      });
+      request = await fastify.inject({
+        method: 'GET',
+        url: `/ordinals/brc-20/activity?address=${address}`,
+      });
+      json = request.json();
+      expect(json.total).toBe(6);
+      expect(json.results).toHaveLength(6);
+      expect(json.results[0].operation).toBe('mint');
+
+      // Rollback: 🔥 is un-minted
+      await db.updateInscriptions(rollBack(mintFIRE));
       request = await fastify.inject({
         method: 'GET',
         url: `/ordinals/brc-20/tokens/🔥`,
@@ -3421,31 +3497,7 @@ describe('BRC-20', () => {
       expect(json.results).toHaveLength(0);
 
       // Rollback 2: 🔥 is un-deployed
-      await db.updateInscriptions(
-        new TestChainhookPayloadBuilder()
-          .rollback()
-          .block({
-            height: 775621,
-            hash: '000000000000000000033b0b78ff68c5767109f45ee42696bd4db9b2845a7ea8',
-          })
-          .transaction({
-            hash: '8354e85e87fa2df8b3a06ec0b9d395559b95174530cb19447fc4df5f6d4ca84d',
-          })
-          .inscriptionRevealed(
-            brc20Reveal({
-              json: {
-                p: 'brc-20',
-                op: 'deploy',
-                tick: '🔥',
-                max: '1000',
-              },
-              number: 50,
-              tx_id: '8354e85e87fa2df8b3a06ec0b9d395559b95174530cb19447fc4df5f6d4ca84d',
-              address: address,
-            })
-          )
-          .build()
-      );
+      await db.updateInscriptions(rollBack(deployFIRE));
       request = await fastify.inject({
         method: 'GET',
         url: `/ordinals/brc-20/tokens/🔥`,
@@ -3481,28 +3533,7 @@ describe('BRC-20', () => {
       expect(json.results[0].operation).toBe('transfer_send');
 
       // Rollback 3: PEPE is un-sent
-      await db.updateInscriptions(
-        new TestChainhookPayloadBuilder()
-          .rollback()
-          .block({
-            height: 775620,
-            hash: '000000000000000000016ddf56d0fe72476165acee9500d48d3e2aaf8412f489',
-          })
-          .transaction({
-            hash: '7edaa48337a94da327b6262830505f116775a32db5ad4ad46e87ecea33f21bac',
-          })
-          .inscriptionTransferred({
-            inscription_id: 'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47ai0',
-            updated_address: address2,
-            satpoint_pre_transfer:
-              'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47a:0:0',
-            satpoint_post_transfer:
-              '7edaa48337a94da327b6262830505f116775a32db5ad4ad46e87ecea33f21bac:0:0',
-            post_transfer_output_value: null,
-            tx_index: 0,
-          })
-          .build()
-      );
+      await db.updateInscriptions(rollBack(sendPEPE));
       request = await fastify.inject({
         method: 'GET',
         url: `/ordinals/brc-20/balances/${address}`,
@@ -3539,31 +3570,7 @@ describe('BRC-20', () => {
       expect(json.results[0].operation).toBe('transfer');
 
       // Rollback 4: PEPE is un-transferred
-      await db.updateInscriptions(
-        new TestChainhookPayloadBuilder()
-          .rollback()
-          .block({
-            height: 775619,
-            hash: '00000000000000000002b14f0c5dde0b2fc74d022e860696bd64f1f652756674',
-          })
-          .transaction({
-            hash: 'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47a',
-          })
-          .inscriptionRevealed(
-            brc20Reveal({
-              json: {
-                p: 'brc-20',
-                op: 'transfer',
-                tick: 'PEPE',
-                amt: '9000',
-              },
-              number: 7,
-              tx_id: 'eee52b22397ea4a4aefe6a39931315e93a157091f5a994216c0aa9c8c6fef47a',
-              address: address,
-            })
-          )
-          .build()
-      );
+      await db.updateInscriptions(rollBack(transferPEPE));
       request = await fastify.inject({
         method: 'GET',
         url: `/ordinals/brc-20/balances/${address}`,

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -106,6 +106,14 @@ export class TestChainhookPayloadBuilder {
   }
 }
 
+export function rollBack(payload: Payload) {
+  return {
+    ...payload,
+    apply: [],
+    rollback: payload.apply,
+  };
+}
+
 export function brc20Reveal(args: {
   json: Brc20;
   number: number;


### PR DESCRIPTION
Add a `brc20_counts_by_address_event_type` table that tracks activity count per address so we can optimize paginated results on `/brc-20/activity?address=` endpoint calls.

Also, fix a BRC-20 `transfer_send` rollback issue when it was a self-transfer