### PR TITLE
refactor: move tests to folders within `src`

### DIFF
--- a/src/api/routes/__tests__/inscriptions.test.ts
+++ b/src/api/routes/__tests__/inscriptions.test.ts
@@ -1,7 +1,7 @@
 import { cycleMigrations } from '@hirosystems/api-toolkit';
-import { buildApiServer } from '../src/api/init';
-import { MIGRATIONS_DIR, PgStore } from '../src/pg/pg-store';
-import { TestChainhookPayloadBuilder, TestFastifyServer } from './helpers';
+import { buildApiServer } from '../../init';
+import { MIGRATIONS_DIR, PgStore } from '../../../pg/pg-store';
+import { TestChainhookPayloadBuilder, TestFastifyServer } from '../../../../tests/helpers';
 import {
   BitcoinInscriptionRevealed,
   BitcoinInscriptionTransferred,

--- a/src/api/routes/__tests__/sats.test.ts
+++ b/src/api/routes/__tests__/sats.test.ts
@@ -1,7 +1,7 @@
 import { cycleMigrations } from '@hirosystems/api-toolkit';
-import { buildApiServer } from '../src/api/init';
-import { MIGRATIONS_DIR, PgStore } from '../src/pg/pg-store';
-import { TestChainhookPayloadBuilder, TestFastifyServer } from './helpers';
+import { TestFastifyServer, TestChainhookPayloadBuilder } from '../../../../tests/helpers';
+import { PgStore, MIGRATIONS_DIR } from '../../../pg/pg-store';
+import { buildApiServer } from '../../init';
 
 describe('/sats', () => {
   let db: PgStore;

--- a/src/api/routes/__tests__/stats.test.ts
+++ b/src/api/routes/__tests__/stats.test.ts
@@ -1,7 +1,11 @@
 import { cycleMigrations } from '@hirosystems/api-toolkit';
-import { buildApiServer } from '../src/api/init';
-import { MIGRATIONS_DIR, PgStore } from '../src/pg/pg-store';
-import { TestChainhookPayloadBuilder, TestFastifyServer, randomHash } from './helpers';
+import {
+  TestFastifyServer,
+  randomHash,
+  TestChainhookPayloadBuilder,
+} from '../../../../tests/helpers';
+import { PgStore, MIGRATIONS_DIR } from '../../../pg/pg-store';
+import { buildApiServer } from '../../init';
 
 describe('/stats', () => {
   let db: PgStore;

--- a/src/api/routes/__tests__/status.test.ts
+++ b/src/api/routes/__tests__/status.test.ts
@@ -1,7 +1,7 @@
 import { cycleMigrations } from '@hirosystems/api-toolkit';
-import { buildApiServer } from '../src/api/init';
-import { MIGRATIONS_DIR, PgStore } from '../src/pg/pg-store';
-import { TestChainhookPayloadBuilder, TestFastifyServer } from './helpers';
+import { TestFastifyServer, TestChainhookPayloadBuilder } from '../../../../tests/helpers';
+import { PgStore, MIGRATIONS_DIR } from '../../../pg/pg-store';
+import { buildApiServer } from '../../init';
 
 describe('Status', () => {
   let db: PgStore;

--- a/src/api/util/__tests__/ordinal-satoshi.test.ts
+++ b/src/api/util/__tests__/ordinal-satoshi.test.ts
@@ -1,4 +1,4 @@
-import { OrdinalSatoshi, SatoshiRarity } from '../src/api/util/ordinal-satoshi';
+import { OrdinalSatoshi, SatoshiRarity } from '../ordinal-satoshi';
 
 describe('OrdinalSatoshi', () => {
   test('mythic sat', () => {

--- a/src/api/util/cache.ts
+++ b/src/api/util/cache.ts
@@ -45,7 +45,7 @@ async function handleCache(type: ETagType, request: FastifyRequest, reply: Fasti
       etag = await getInscriptionsIndexEtag(request);
       break;
     case ETagType.inscriptionsPerBlock:
-      etag = await request.server.db.getInscriptionsPerBlockETag();
+      etag = await request.server.db.cache.getInscriptionsPerBlockETag();
       break;
   }
   if (etag) {
@@ -75,9 +75,9 @@ async function getInscriptionLocationEtag(request: FastifyRequest): Promise<stri
       const lastElement = components.pop();
       if (lastElement && lastElement.length) {
         if (InscriptionIdParamCType.Check(lastElement)) {
-          return await request.server.db.getInscriptionETag({ genesis_id: lastElement });
+          return await request.server.db.cache.getInscriptionETag({ genesis_id: lastElement });
         } else if (InscriptionNumberParamCType.Check(parseInt(lastElement))) {
-          return await request.server.db.getInscriptionETag({ number: lastElement });
+          return await request.server.db.cache.getInscriptionETag({ number: lastElement });
         }
       }
     } while (components.length);
@@ -93,7 +93,7 @@ async function getInscriptionLocationEtag(request: FastifyRequest): Promise<stri
  */
 async function getInscriptionsIndexEtag(request: FastifyRequest): Promise<string | undefined> {
   try {
-    return await request.server.db.getInscriptionsIndexETag();
+    return await request.server.db.cache.getInscriptionsIndexETag();
   } catch (error) {
     return;
   }

--- a/src/chainhook/__tests__/server.test.ts
+++ b/src/chainhook/__tests__/server.test.ts
@@ -1,13 +1,13 @@
-import { PREDICATE_UUID, startChainhookServer } from '../src/chainhook/server';
-import { ENV } from '../src/env';
-import { MIGRATIONS_DIR, PgStore } from '../src/pg/pg-store';
-import { TestChainhookPayloadBuilder, TestFastifyServer } from './helpers';
+import { PREDICATE_UUID, startChainhookServer } from '../server';
+import { ENV } from '../../env';
+import { MIGRATIONS_DIR, PgStore } from '../../pg/pg-store';
+import { TestChainhookPayloadBuilder, TestFastifyServer } from '../../../tests/helpers';
 import {
   BitcoinInscriptionRevealed,
   BitcoinInscriptionTransferred,
   ChainhookEventObserver,
 } from '@hirosystems/chainhook-client';
-import { buildApiServer } from '../src/api/init';
+import { buildApiServer } from '../../api/init';
 import { cycleMigrations } from '@hirosystems/api-toolkit';
 
 describe('EventServer', () => {

--- a/src/pg/cache/__tests__/cache.test.ts
+++ b/src/pg/cache/__tests__/cache.test.ts
@@ -1,7 +1,11 @@
 import { cycleMigrations } from '@hirosystems/api-toolkit';
-import { buildApiServer } from '../src/api/init';
-import { MIGRATIONS_DIR, PgStore } from '../src/pg/pg-store';
-import { TestChainhookPayloadBuilder, TestFastifyServer, randomHash } from './helpers';
+import { buildApiServer } from '../../../api/init';
+import { MIGRATIONS_DIR, PgStore } from '../../pg-store';
+import {
+  TestFastifyServer,
+  TestChainhookPayloadBuilder,
+  randomHash,
+} from '../../../../tests/helpers';
 
 describe('ETag cache', () => {
   let db: PgStore;

--- a/src/pg/cache/cache-pg-store.ts
+++ b/src/pg/cache/cache-pg-store.ts
@@ -1,0 +1,36 @@
+import { BasePgStoreModule } from '@hirosystems/api-toolkit';
+import { InscriptionIdentifier } from '../pg-store';
+
+export class CachePgStore extends BasePgStoreModule {
+  async getInscriptionETag(args: InscriptionIdentifier): Promise<string | undefined> {
+    const result = await this.sql<{ etag: string }[]>`
+      SELECT date_part('epoch', updated_at)::text AS etag
+      FROM inscriptions
+      WHERE ${
+        'genesis_id' in args
+          ? this.sql`genesis_id = ${args.genesis_id}`
+          : this.sql`number = ${args.number}`
+      }
+    `;
+    if (result.count > 0) {
+      return result[0].etag;
+    }
+  }
+
+  async getInscriptionsIndexETag(): Promise<string> {
+    const result = await this.sql<{ etag: string }[]>`
+      SELECT date_part('epoch', MAX(updated_at))::text AS etag FROM inscriptions
+    `;
+    return result[0].etag;
+  }
+
+  async getInscriptionsPerBlockETag(): Promise<string> {
+    const result = await this.sql<{ block_hash: string; inscription_count: string }[]>`
+      SELECT block_hash, inscription_count
+      FROM inscriptions_per_block
+      ORDER BY block_height DESC
+      LIMIT 1
+    `;
+    return `${result[0].block_hash}:${result[0].inscription_count}`;
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,5 +2,7 @@
   "extends": "./tsconfig.json",
   "exclude": [
     "tests/**/*.ts",
+    "**/__tests__/**",
+    "util/*.ts"
   ]
 }


### PR DESCRIPTION
Also, separate cache pg functions into submodule