### PR TITLE
fix: same-block inscription location pointer comparison

### DIFF
--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -737,7 +737,7 @@ export class PgStore extends BasePgStore {
     const distinctPointers = (
       cond: (a: DbLocationPointerInsert, b: DbLocationPointerInsert) => boolean
     ): DbLocationPointerInsert[] => {
-      const out = new Map<number, DbLocationPointerInsert>();
+      const out = new Map<string, DbLocationPointerInsert>();
       for (const ptr of pointers) {
         if (ptr.inscription_id === null) continue;
         const current = out.get(ptr.inscription_id);
@@ -748,12 +748,12 @@ export class PgStore extends BasePgStore {
 
     await this.sqlWriteTransaction(async sql => {
       const distinctIds = [
-        ...new Set<number>(pointers.map(i => i.inscription_id).filter(v => v !== null)),
+        ...new Set<string>(pointers.map(i => i.inscription_id).filter(v => v !== null)),
       ];
       const genesisPtrs = distinctPointers(
         (a, b) =>
-          a.block_height < b.block_height ||
-          (a.block_height === b.block_height && a.tx_index < b.tx_index)
+          parseInt(a.block_height) < parseInt(b.block_height) ||
+          (parseInt(a.block_height) === parseInt(b.block_height) && parseInt(a.tx_index) < parseInt(b.tx_index))
       );
       if (genesisPtrs.length) {
         const genesis = await sql<{ old_address: string | null; new_address: string | null }[]>`
@@ -784,8 +784,8 @@ export class PgStore extends BasePgStore {
 
       const currentPtrs = distinctPointers(
         (a, b) =>
-          a.block_height > b.block_height ||
-          (a.block_height === b.block_height && a.tx_index > b.tx_index)
+          parseInt(a.block_height) > parseInt(b.block_height) ||
+          (parseInt(a.block_height) === parseInt(b.block_height) && parseInt(a.tx_index) > parseInt(b.tx_index))
       );
       if (currentPtrs.length) {
         const current = await sql<{ old_address: string | null; new_address: string | null }[]>`

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -753,7 +753,8 @@ export class PgStore extends BasePgStore {
       const genesisPtrs = distinctPointers(
         (a, b) =>
           parseInt(a.block_height) < parseInt(b.block_height) ||
-          (parseInt(a.block_height) === parseInt(b.block_height) && parseInt(a.tx_index) < parseInt(b.tx_index))
+          (parseInt(a.block_height) === parseInt(b.block_height) &&
+            parseInt(a.tx_index) < parseInt(b.tx_index))
       );
       if (genesisPtrs.length) {
         const genesis = await sql<{ old_address: string | null; new_address: string | null }[]>`
@@ -785,7 +786,8 @@ export class PgStore extends BasePgStore {
       const currentPtrs = distinctPointers(
         (a, b) =>
           parseInt(a.block_height) > parseInt(b.block_height) ||
-          (parseInt(a.block_height) === parseInt(b.block_height) && parseInt(a.tx_index) > parseInt(b.tx_index))
+          (parseInt(a.block_height) === parseInt(b.block_height) &&
+            parseInt(a.tx_index) > parseInt(b.tx_index))
       );
       if (currentPtrs.length) {
         const current = await sql<{ old_address: string | null; new_address: string | null }[]>`

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -75,10 +75,10 @@ export type DbLocationPointer = {
 };
 
 export type DbLocationPointerInsert = {
-  inscription_id: number;
-  location_id: number;
-  block_height: number;
-  tx_index: number;
+  inscription_id: string;
+  location_id: string;
+  block_height: string;
+  tx_index: string;
   address: string | null;
 };
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -6,7 +6,6 @@ import {
   BitcoinInscriptionRevealed,
   BitcoinInscriptionTransferred,
   ChainhookEventObserver,
-  Payload,
 } from '@hirosystems/chainhook-client';
 import { buildApiServer } from '../src/api/init';
 import { cycleMigrations } from '@hirosystems/api-toolkit';

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -10,7 +10,6 @@ import {
 } from '@hirosystems/chainhook-client';
 import { buildApiServer } from '../src/api/init';
 import { cycleMigrations } from '@hirosystems/api-toolkit';
-import { testBlock } from './808382';
 
 describe('EventServer', () => {
   let db: PgStore;

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -389,10 +389,9 @@ describe('EventServer', () => {
       expect(api4.json().total).toBe(3);
     });
 
-    test('multiple inscription events on the same block are compared correctly', async () => {
+    test('multiple inscription pointers on the same block are compared correctly', async () => {
       const address = 'bc1q92zytmqgczsrg4xuhpc2asz6h4h7ke5hagw8k6';
       const address2 = 'bc1qtpm0fsaawxjsthfdrxhmrzunnpjx0g9hncgvp7';
-      // ENV.INSCRIPTION_WRITE_CHUNK_LIMIT = 1;
       await db.updateInscriptions(
         new TestChainhookPayloadBuilder()
           .apply()
@@ -432,12 +431,10 @@ describe('EventServer', () => {
             satpoint_post_transfer:
               '7edaa48337a94da327b6262830505f116775a32db5ad4ad46e87ecea33f21bac:0:0',
             post_transfer_output_value: null,
-            tx_index: 1019,
+            tx_index: 1019, // '1019' is less than '995' when compared as a string
           })
           .build()
       );
-      // ENV.INSCRIPTION_WRITE_CHUNK_LIMIT = 5000;
-      // await db.updateInscriptions(testBlock as Payload);
       const response = await fastify.inject({
         method: 'GET',
         url: `/ordinals/inscriptions/6046f17804eb8396285567a20c09598ae1273b6f744b23700ba95593c380ce02i0`,
@@ -445,14 +442,6 @@ describe('EventServer', () => {
       expect(response.statusCode).toBe(200);
       const json = response.json();
       expect(json.genesis_address).toBe(address);
-      // expect(json.results).toStrictEqual([
-      //   {
-      //     available_balance: '1000.000000000000000000',
-      //     overall_balance: '10000.000000000000000000',
-      //     ticker: 'PEPE',
-      //     transferrable_balance: '9000.000000000000000000',
-      //   },
-      // ]);
     });
   });
 });


### PR DESCRIPTION
The postgres.js config casts the postgres `numeric` type as a string when returning it to JS, causing number comparisons to break when trying to determine a inscription's genesis when it is created and transferred in the same block.

This PR simply parses values as `number` before comparing block height and transaction index.