### PR TITLE
feat: return `parent` and `metadata` in inscription responses

### DIFF
--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -331,6 +331,7 @@ export const InscriptionResponse = Type.Object(
         examples: ['1463d48e9248159084929294f64bda04487503d30ce7ab58365df1dc6fd58218i0'],
       })
     ),
+    metadata: Nullable(Type.Any()),
   },
   { title: 'Inscription Response' }
 );

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -326,6 +326,11 @@ export const InscriptionResponse = Type.Object(
         })
       )
     ),
+    parent: Nullable(
+      Type.String({
+        examples: ['1463d48e9248159084929294f64bda04487503d30ce7ab58365df1dc6fd58218i0'],
+      })
+    ),
   },
   { title: 'Inscription Response' }
 );

--- a/src/api/util/helpers.ts
+++ b/src/api/util/helpers.ts
@@ -55,6 +55,7 @@ export function parseDbInscriptions(
     curse_type: i.curse_type,
     recursive: i.recursive,
     recursion_refs: i.recursion_refs?.split(',') ?? null,
+    parent: i.parent,
   }));
 }
 export function parseDbInscription(item: DbFullyLocatedInscriptionResult): InscriptionResponseType {

--- a/src/api/util/helpers.ts
+++ b/src/api/util/helpers.ts
@@ -56,6 +56,7 @@ export function parseDbInscriptions(
     recursive: i.recursive,
     recursion_refs: i.recursion_refs?.split(',') ?? null,
     parent: i.parent,
+    metadata: i.metadata ? JSON.parse(i.metadata) : null,
   }));
 }
 export function parseDbInscription(item: DbFullyLocatedInscriptionResult): InscriptionResponseType {

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -589,6 +589,7 @@ export class PgStore extends BasePgStore {
           i.fee AS genesis_fee,
           i.curse_type,
           i.ordinal_number AS sat_ordinal,
+          i.parent,
           s.rarity AS sat_rarity,
           s.coinbase_height AS sat_coinbase_height,
           i.recursive,

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -590,6 +590,7 @@ export class PgStore extends BasePgStore {
           i.curse_type,
           i.ordinal_number AS sat_ordinal,
           i.parent,
+          i.metadata,
           s.rarity AS sat_rarity,
           s.coinbase_height AS sat_coinbase_height,
           i.recursive,

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -100,6 +100,7 @@ export type DbFullyLocatedInscriptionResult = {
   curse_type: string | null;
   recursive: boolean;
   recursion_refs: string | null;
+  parent: string | null;
 };
 
 export enum DbLocationTransferType {

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -101,6 +101,7 @@ export type DbFullyLocatedInscriptionResult = {
   recursive: boolean;
   recursion_refs: string | null;
   parent: string | null;
+  metadata: string | null;
 };
 
 export enum DbLocationTransferType {

--- a/tests/api/inscriptions.test.ts
+++ b/tests/api/inscriptions.test.ts
@@ -299,6 +299,81 @@ describe('/inscriptions', () => {
       expect(response2.json()).toStrictEqual(expected);
     });
 
+    test('shows inscription with parent', async () => {
+      await db.updateInscriptions(
+        new TestChainhookPayloadBuilder()
+          .apply()
+          .block({
+            height: 778575,
+            hash: '0x00000000000000000002a90330a99f67e3f01eb2ce070b45930581e82fb7a91d',
+            timestamp: 1676913207,
+          })
+          .transaction({
+            hash: '0x9f4a9b73b0713c5da01c0a47f97c6c001af9028d6bdd9e264dfacbc4e6790201',
+          })
+          .inscriptionRevealed({
+            content_bytes: `0x010101`,
+            content_type: 'text/plain;charset=utf-8',
+            content_length: 5,
+            inscription_number: { classic: 0, jubilee: 0 },
+            inscription_fee: 705,
+            inscription_id: '9f4a9b73b0713c5da01c0a47f97c6c001af9028d6bdd9e264dfacbc4e6790201i0',
+            inscription_output_value: 10000,
+            inscriber_address: 'bc1pscktlmn99gyzlvymvrezh6vwd0l4kg06tg5rvssw0czg8873gz5sdkteqj',
+            ordinal_number: 257418248345364,
+            ordinal_block_height: 650000,
+            ordinal_offset: 0,
+            satpoint_post_inscription:
+              '9f4a9b73b0713c5da01c0a47f97c6c001af9028d6bdd9e264dfacbc4e6790201:0:0',
+            tx_index: 0,
+            inscription_input_index: 0,
+            transfers_pre_inscription: 0,
+            curse_type: null,
+            inscription_pointer: null,
+            delegate: null,
+            metaprotocol: null,
+            metadata: null,
+            parent: null,
+          })
+          .transaction({
+            hash: '0xf351d86c6e6cae3c64e297e7463095732f216875bcc1f3c03f950a492bb25421',
+          })
+          .inscriptionRevealed({
+            content_bytes: '0x48656C6C6F',
+            content_type: 'image/png',
+            content_length: 5,
+            inscription_number: { classic: 1, jubilee: 1 },
+            inscription_fee: 2805,
+            inscription_id: 'f351d86c6e6cae3c64e297e7463095732f216875bcc1f3c03f950a492bb25421i0',
+            inscription_output_value: 10000,
+            inscriber_address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
+            ordinal_number: 257418248345364,
+            ordinal_block_height: 51483,
+            ordinal_offset: 0,
+            satpoint_post_inscription:
+              'f351d86c6e6cae3c64e297e7463095732f216875bcc1f3c03f950a492bb25421:0:0',
+            inscription_input_index: 0,
+            transfers_pre_inscription: 0,
+            tx_index: 0,
+            curse_type: null,
+            inscription_pointer: null,
+            delegate: null,
+            metaprotocol: null,
+            metadata: null,
+            parent: '9f4a9b73b0713c5da01c0a47f97c6c001af9028d6bdd9e264dfacbc4e6790201i0',
+          })
+          .build()
+      );
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/ordinals/v1/inscriptions/f351d86c6e6cae3c64e297e7463095732f216875bcc1f3c03f950a492bb25421i0',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.json().parent).toBe(
+        '9f4a9b73b0713c5da01c0a47f97c6c001af9028d6bdd9e264dfacbc4e6790201i0'
+      );
+    });
+
     test('shows inscription with empty genesis address', async () => {
       await db.updateInscriptions(
         new TestChainhookPayloadBuilder()

--- a/tests/api/inscriptions.test.ts
+++ b/tests/api/inscriptions.test.ts
@@ -374,6 +374,52 @@ describe('/inscriptions', () => {
       );
     });
 
+    test('shows inscription with metadata', async () => {
+      await db.updateInscriptions(
+        new TestChainhookPayloadBuilder()
+          .apply()
+          .block({
+            height: 778575,
+            hash: '0x00000000000000000002a90330a99f67e3f01eb2ce070b45930581e82fb7a91d',
+            timestamp: 1676913207,
+          })
+          .transaction({
+            hash: '0x9f4a9b73b0713c5da01c0a47f97c6c001af9028d6bdd9e264dfacbc4e6790201',
+          })
+          .inscriptionRevealed({
+            content_bytes: `0x010101`,
+            content_type: 'text/plain;charset=utf-8',
+            content_length: 5,
+            inscription_number: { classic: 0, jubilee: 0 },
+            inscription_fee: 705,
+            inscription_id: '9f4a9b73b0713c5da01c0a47f97c6c001af9028d6bdd9e264dfacbc4e6790201i0',
+            inscription_output_value: 10000,
+            inscriber_address: 'bc1pscktlmn99gyzlvymvrezh6vwd0l4kg06tg5rvssw0czg8873gz5sdkteqj',
+            ordinal_number: 257418248345364,
+            ordinal_block_height: 650000,
+            ordinal_offset: 0,
+            satpoint_post_inscription:
+              '9f4a9b73b0713c5da01c0a47f97c6c001af9028d6bdd9e264dfacbc4e6790201:0:0',
+            tx_index: 0,
+            inscription_input_index: 0,
+            transfers_pre_inscription: 0,
+            curse_type: null,
+            inscription_pointer: null,
+            delegate: null,
+            metaprotocol: null,
+            metadata: { foo: 'bar', test: 1337 },
+            parent: null,
+          })
+          .build()
+      );
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/ordinals/v1/inscriptions/9f4a9b73b0713c5da01c0a47f97c6c001af9028d6bdd9e264dfacbc4e6790201i0',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.json().metadata).toStrictEqual({ foo: 'bar', test: 1337 });
+    });
+
     test('shows inscription with empty genesis address', async () => {
       await db.updateInscriptions(
         new TestChainhookPayloadBuilder()

--- a/tests/api/inscriptions.test.ts
+++ b/tests/api/inscriptions.test.ts
@@ -124,6 +124,8 @@ describe('/inscriptions', () => {
         curse_type: null,
         recursive: false,
         recursion_refs: null,
+        parent: null,
+        metadata: null,
       };
 
       // By inscription id
@@ -280,6 +282,8 @@ describe('/inscriptions', () => {
           'f351d86c6e6cae3c64e297e7463095732f216875bcc1f3c03f950a492bb25421i0',
           'b4b27b9a15f928b95a8ce4b418946553b7b313a345254cd9b23d79489175fa5ai0',
         ],
+        parent: null,
+        metadata: null,
       };
 
       // By inscription id
@@ -483,6 +487,8 @@ describe('/inscriptions', () => {
         curse_type: null,
         recursive: false,
         recursion_refs: null,
+        parent: null,
+        metadata: null,
       };
 
       // By inscription id
@@ -565,6 +571,8 @@ describe('/inscriptions', () => {
         curse_type: '88',
         recursive: false,
         recursion_refs: null,
+        parent: null,
+        metadata: null,
       };
 
       // By inscription id
@@ -676,6 +684,8 @@ describe('/inscriptions', () => {
         curse_type: null,
         recursive: false,
         recursion_refs: null,
+        parent: null,
+        metadata: null,
       });
 
       // Transfer 2
@@ -731,6 +741,8 @@ describe('/inscriptions', () => {
         curse_type: null,
         recursive: false,
         recursion_refs: null,
+        parent: null,
+        metadata: null,
       });
     });
 
@@ -841,6 +853,8 @@ describe('/inscriptions', () => {
         curse_type: null,
         recursive: false,
         recursion_refs: null,
+        parent: null,
+        metadata: null,
       });
     });
 
@@ -936,6 +950,8 @@ describe('/inscriptions', () => {
         curse_type: '{"tag":66}',
         recursive: false,
         recursion_refs: null,
+        parent: null,
+        metadata: null,
       });
 
       // Transfer 2
@@ -991,6 +1007,8 @@ describe('/inscriptions', () => {
         curse_type: '{"tag":66}',
         recursive: false,
         recursion_refs: null,
+        parent: null,
+        metadata: null,
       });
     });
   });
@@ -1636,6 +1654,8 @@ describe('/inscriptions', () => {
           curse_type: null,
           recursive: false,
           recursion_refs: null,
+          parent: null,
+          metadata: null,
         },
         {
           address: 'bc1pscktlmn99gyzlvymvrezh6vwd0l4kg06tg5rvssw0czg8873gz5sdkteqj',
@@ -1662,6 +1682,8 @@ describe('/inscriptions', () => {
           curse_type: null,
           recursive: false,
           recursion_refs: null,
+          parent: null,
+          metadata: null,
         },
       ]);
     });
@@ -1775,6 +1797,8 @@ describe('/inscriptions', () => {
           curse_type: null,
           recursive: false,
           recursion_refs: null,
+          parent: null,
+          metadata: null,
         };
         expect(responseJson1.results[0]).toStrictEqual(result1);
 
@@ -1810,6 +1834,8 @@ describe('/inscriptions', () => {
           curse_type: null,
           recursive: false,
           recursion_refs: null,
+          parent: null,
+          metadata: null,
         };
         expect(responseJson2.results[0]).toStrictEqual(result2);
 

--- a/tests/api/sats.test.ts
+++ b/tests/api/sats.test.ts
@@ -184,6 +184,7 @@ describe('/sats', () => {
         curse_type: '"p2wsh"',
         recursive: false,
         recursion_refs: null,
+        parent: null,
       },
       {
         address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
@@ -211,6 +212,7 @@ describe('/sats', () => {
         curse_type: '"p2wsh"',
         recursive: false,
         recursion_refs: null,
+        parent: null,
       },
     ]);
 

--- a/tests/api/sats.test.ts
+++ b/tests/api/sats.test.ts
@@ -185,6 +185,7 @@ describe('/sats', () => {
         recursive: false,
         recursion_refs: null,
         parent: null,
+        metadata: null,
       },
       {
         address: 'bc1p3cyx5e2hgh53w7kpxcvm8s4kkega9gv5wfw7c4qxsvxl0u8x834qf0u2td',
@@ -213,6 +214,7 @@ describe('/sats', () => {
         recursive: false,
         recursion_refs: null,
         parent: null,
+        metadata: null,
       },
     ]);
 


### PR DESCRIPTION
Fixes #333 