### PR TITLE
fix: add output to current locations and block_hash to inscriptions

### DIFF
--- a/migrations/1718498685557_inscriptions-block-hash.ts
+++ b/migrations/1718498685557_inscriptions-block-hash.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.addColumn('inscriptions', {
+    block_hash: {
+      type: 'text',
+    },
+  });
+  pgm.sql(`
+    UPDATE inscriptions SET block_hash = (
+      SELECT block_hash FROM locations AS l WHERE l.ordinal_number = ordinal_number LIMIT 1
+    )  
+  `);
+  pgm.alterColumn('inscriptions', 'block_hash', { notNull: true });
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropColumn('inscriptions', 'block_hash');
+}

--- a/migrations/1718498703916_current-locations-output.ts
+++ b/migrations/1718498703916_current-locations-output.ts
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.addColumn('current_locations', {
+    output: {
+      type: 'text',
+    },
+  });
+  pgm.sql(`
+    UPDATE current_locations SET output = (
+      SELECT output FROM locations AS l
+      WHERE l.ordinal_number = ordinal_number
+        AND l.block_height = block_height
+        AND l.tx_index = tx_index
+      LIMIT 1
+    )  
+  `);
+  pgm.alterColumn('current_locations', 'output', { notNull: true });
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.dropColumn('current_locations', 'output');
+}

--- a/src/pg/block-cache.ts
+++ b/src/pg/block-cache.ts
@@ -54,12 +54,14 @@ export class BlockCache {
     const recursive_refs = getInscriptionRecursion(reveal.content_bytes);
     const content_type = removeNullBytes(reveal.content_type);
     const mime_type = content_type.split(';')[0];
+    const output = `${satpoint.tx_id}:${satpoint.vout}`;
     this.inscriptions.push({
       genesis_id: reveal.inscription_id,
       mime_type,
       content_type,
       content_length: reveal.content_length,
       block_height: this.blockHeight,
+      block_hash: this.blockHash,
       tx_index: reveal.tx_index,
       address: reveal.inscriber_address ?? '',
       number: reveal.inscription_number.jubilee,
@@ -87,7 +89,7 @@ export class BlockCache {
       tx_index: reveal.tx_index,
       ordinal_number,
       address: reveal.inscriber_address ?? '',
-      output: `${satpoint.tx_id}:${satpoint.vout}`,
+      output,
       offset: satpoint.offset ?? null,
       prev_output: null,
       prev_offset: null,
@@ -99,6 +101,7 @@ export class BlockCache {
       ordinal_number,
       block_height: this.blockHeight,
       tx_index: reveal.tx_index,
+      output,
       address: reveal.inscriber_address ?? '',
     });
     if (recursive_refs.length > 0) this.recursiveRefs.set(reveal.inscription_id, recursive_refs);
@@ -109,6 +112,7 @@ export class BlockCache {
     const prevSatpoint = parseSatPoint(transfer.satpoint_pre_transfer);
     const ordinal_number = transfer.ordinal_number.toString();
     const address = transfer.destination.value ?? '';
+    const output = `${satpoint.tx_id}:${satpoint.vout}`;
     this.locations.push({
       block_hash: this.blockHash,
       block_height: this.blockHeight,
@@ -116,7 +120,7 @@ export class BlockCache {
       tx_index: transfer.tx_index,
       ordinal_number,
       address,
-      output: `${satpoint.tx_id}:${satpoint.vout}`,
+      output,
       offset: satpoint.offset ?? null,
       prev_output: `${prevSatpoint.tx_id}:${prevSatpoint.vout}`,
       prev_offset: prevSatpoint.offset ?? null,
@@ -132,6 +136,7 @@ export class BlockCache {
       ordinal_number,
       block_height: this.blockHeight,
       tx_index: transfer.tx_index,
+      output,
       address,
     });
   }

--- a/src/pg/pg-store.ts
+++ b/src/pg/pg-store.ts
@@ -330,9 +330,9 @@ export class PgStore extends BasePgStore {
     if (cache.currentLocations.size) {
       for (const ordinal_number of moved_sats) {
         await sql`
-          INSERT INTO current_locations (ordinal_number, block_height, tx_index, address)
+          INSERT INTO current_locations (ordinal_number, block_height, tx_index, output, address)
           (
-            SELECT ordinal_number, block_height, tx_index, address
+            SELECT ordinal_number, block_height, tx_index, output, address
             FROM locations
             WHERE ordinal_number = ${ordinal_number}
             ORDER BY block_height DESC, tx_index DESC
@@ -545,9 +545,9 @@ export class PgStore extends BasePgStore {
                 : sql``
             }
             ${
-              /*filters?.genesis_block_hash
-                ? sql`AND gen_l.block_hash = ${filters.genesis_block_hash}`
-                :*/ sql``
+              filters?.genesis_block_hash
+                ? sql`AND i.block_hash = ${filters.genesis_block_hash}`
+                : sql``
             }
             ${
               filters?.from_genesis_block_height
@@ -600,7 +600,7 @@ export class PgStore extends BasePgStore {
             ${
               filters?.mime_type?.length ? sql`AND i.mime_type IN ${sql(filters.mime_type)}` : sql``
             }
-            ${/*filters?.output ? sql`AND cur_l.output = ${filters.output}` : */ sql``}
+            ${filters?.output ? sql`AND cur.output = ${filters.output}` : sql``}
             ${filters?.sat_rarity?.length ? sql`AND s.rarity IN ${sql(filters.sat_rarity)}` : sql``}
             ${filters?.sat_ordinal ? sql`AND i.ordinal_number = ${filters.sat_ordinal}` : sql``}
             ${

--- a/src/pg/types.ts
+++ b/src/pg/types.ts
@@ -14,6 +14,7 @@ export type DbInscriptionInsert = {
   number: number;
   classic_number: number;
   block_height: number;
+  block_hash: string;
   tx_index: number;
   address: string;
   mime_type: string;
@@ -48,6 +49,7 @@ export type DbCurrentLocationInsert = {
   ordinal_number: PgNumeric;
   block_height: number;
   tx_index: number;
+  output: string;
   address: string;
 };
 

--- a/tests/api/inscriptions.test.ts
+++ b/tests/api/inscriptions.test.ts
@@ -2318,7 +2318,7 @@ describe('/inscriptions', () => {
         expect(responseJson4.results[1].genesis_block_height).toBe(778575);
       });
 
-      test.skip('index filtered by block hash', async () => {
+      test('index filtered by block hash', async () => {
         await db.updateInscriptions(
           new TestChainhookPayloadBuilder()
             .apply()
@@ -2794,7 +2794,7 @@ describe('/inscriptions', () => {
         expect(responseJson3.results[0].number).toBe(0);
       });
 
-      test.skip('index filtered by output', async () => {
+      test('index filtered by output', async () => {
         await db.updateInscriptions(
           new TestChainhookPayloadBuilder()
             .apply()


### PR DESCRIPTION
Reestablish filters by block_hash and output that were temporarily disabled